### PR TITLE
/blocks/ details and check chain ID

### DIFF
--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -177,6 +177,12 @@ namespace Libplanet.Explorer.Executable
                 return 1;
             }
 
+            if (!store.ListNamespaces().Contains(chainId))
+            {
+                stderr.WriteLine("error: {0} was not found.", chainId);
+                return 1;
+            }
+
             Startup.StoreState = store;
 
             if (portString is null)

--- a/Libplanet.Explorer/Controllers/ExplorerController.cs
+++ b/Libplanet.Explorer/Controllers/ExplorerController.cs
@@ -52,7 +52,9 @@ namespace Libplanet.Explorer.Controllers
                 {
                     { "hash", block.Hash.ToString() },
                     { "timestamp", block.Timestamp.ToString(TimestampFormat) },
+                    { "miner", block.Miner.ToString() },
                     { "tx_count", block.Transactions.Count().ToString() },
+                    { "difficulty", block.Difficulty.ToString() },
                 })
                 .ToList();
         }


### PR DESCRIPTION
This PR adds `miner` and `difficulty` to `/blocks` response.  and also adds checking to chain ID existence when start-up 