### PR TITLE
Add GraphiQL Interface

### DIFF
--- a/Libplanet.Explorer.Executable/wwwroot/graphiql.html
+++ b/Libplanet.Explorer.Executable/wwwroot/graphiql.html
@@ -1,0 +1,149 @@
+<!--
+ *  Copyright (c) Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the license found in the
+ *  LICENSE file in the root directory of this source tree.
+-->
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      body {
+        height: 100%;
+        margin: 0;
+        width: 100%;
+        overflow: hidden;
+      }
+      #graphiql {
+        height: 100vh;
+      }
+    </style>
+
+    <!--
+      This GraphiQL example depends on Promise and fetch, which are available in
+      modern browsers, but can be "polyfilled" for older browsers.
+      GraphiQL itself depends on React DOM.
+      If you do not want to rely on a CDN, you can host these files locally or
+      include them directly in your favored resource bunder.
+    -->
+    <script src="//cdn.jsdelivr.net/es6-promise/4.0.5/es6-promise.auto.min.js"></script>
+    <script src="//cdn.jsdelivr.net/fetch/0.9.0/fetch.min.js"></script>
+    <script src="//cdn.jsdelivr.net/react/15.4.2/react.min.js"></script>
+    <script src="//cdn.jsdelivr.net/react/15.4.2/react-dom.min.js"></script>
+
+    <!--
+      These two files can be found in the npm module, however you may wish to
+      copy them directly into your environment, or perhaps include them in your
+      favored resource bundler.
+     -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.13.0/graphiql.css" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.13.0/graphiql.js" charset="utf-8"></script>
+
+  </head>
+  <body>
+    <div id="graphiql">Loading...</div>
+    <script>
+
+      /**
+       * This GraphiQL example illustrates how to use some of GraphiQL's props
+       * in order to enable reading and updating the URL parameters, making
+       * link sharing of queries a little bit easier.
+       *
+       * This is only one example of this kind of feature, GraphiQL exposes
+       * various React params to enable interesting integrations.
+       */
+
+      // Parse the search string to get url parameters.
+      var search = window.location.search;
+      var parameters = {};
+      search.substr(1).split('&').forEach(function (entry) {
+        var eq = entry.indexOf('=');
+        if (eq >= 0) {
+          parameters[decodeURIComponent(entry.slice(0, eq))] =
+            decodeURIComponent(entry.slice(eq + 1));
+        }
+      });
+
+      // if variables was provided, try to format it.
+      if (parameters.variables) {
+        try {
+          parameters.variables =
+            JSON.stringify(JSON.parse(parameters.variables), null, 2);
+        } catch (e) {
+          // Do nothing, we want to display the invalid JSON as a string, rather
+          // than present an error.
+        }
+      }
+
+      // When the query and variables string is edited, update the URL bar so
+      // that it can be easily shared
+      function onEditQuery(newQuery) {
+        parameters.query = newQuery;
+        updateURL();
+      }
+
+      function onEditVariables(newVariables) {
+        parameters.variables = newVariables;
+        updateURL();
+      }
+
+      function onEditOperationName(newOperationName) {
+        parameters.operationName = newOperationName;
+        updateURL();
+      }
+
+      function updateURL() {
+        var newSearch = '?' + Object.keys(parameters).filter(function (key) {
+          return Boolean(parameters[key]);
+        }).map(function (key) {
+          return encodeURIComponent(key) + '=' +
+            encodeURIComponent(parameters[key]);
+        }).join('&');
+        history.replaceState(null, null, newSearch);
+      }
+
+      // Defines a GraphQL fetcher using the fetch API. You're not required to
+      // use fetch, and could instead implement graphQLFetcher however you like,
+      // as long as it returns a Promise or Observable.
+      function graphQLFetcher(graphQLParams) {
+        // This example expects a GraphQL server at the path /graphql.
+        // Change this to point wherever you host your GraphQL server.
+        return fetch('/graphql/', {
+          method: 'post',
+          headers: {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(graphQLParams),
+          credentials: 'include',
+        }).then(function (response) {
+          return response.text();
+        }).then(function (responseBody) {
+          try {
+            return JSON.parse(responseBody);
+          } catch (error) {
+            return responseBody;
+          }
+        });
+      }
+
+      // Render <GraphiQL /> into the body.
+      // See the README in the top level of this module to learn more about
+      // how you can customize GraphiQL by providing different values or
+      // additional child elements.
+      ReactDOM.render(
+        React.createElement(GraphiQL, {
+          fetcher: graphQLFetcher,
+          query: parameters.query,
+          variables: parameters.variables,
+          operationName: parameters.operationName,
+          onEditQuery: onEditQuery,
+          onEditVariables: onEditVariables,
+          onEditOperationName: onEditOperationName
+        }),
+        document.getElementById('graphiql')
+      );
+    </script>
+  </body>
+</html>

--- a/Libplanet.Explorer/Controllers/ExplorerController.cs
+++ b/Libplanet.Explorer/Controllers/ExplorerController.cs
@@ -17,6 +17,11 @@ using Libplanet.Explorer.GraphTypes;
 
 namespace Libplanet.Explorer.Controllers
 {
+    public class GraphQLBody
+    {
+        public string Query { get; set; }
+    }
+
     [GenericControllerNameConvention]
     public class ExplorerController<T> : Controller where T : IAction, new()
     {
@@ -40,15 +45,15 @@ namespace Libplanet.Explorer.Controllers
             return chain;
         }
 
-        [HttpGet("/graphql/")]
+        [HttpPost("/graphql/")]
         public IActionResult GetGraphQLResult(
-            [FromQuery(Name = "query")] string query
+            [FromBody] GraphQLBody body
         )
         {
             var schema = new Schema { Query = new BlocksQuery<T>(GetBlockChain()) };
             var json = schema.Execute(_ =>
             {
-                _.Query = query;
+                _.Query = body.Query;
             });
             return Ok(json);
         }

--- a/Libplanet.Explorer/Controllers/ExplorerController.cs
+++ b/Libplanet.Explorer/Controllers/ExplorerController.cs
@@ -14,12 +14,14 @@ using Microsoft.AspNetCore.Mvc;
 using GraphQL;
 using GraphQL.Types;
 using Libplanet.Explorer.GraphTypes;
+using Newtonsoft.Json.Linq;
 
 namespace Libplanet.Explorer.Controllers
 {
     public class GraphQLBody
     {
         public string Query { get; set; }
+        public JObject Variables { get; set; }
     }
 
     [GenericControllerNameConvention]
@@ -54,8 +56,10 @@ namespace Libplanet.Explorer.Controllers
             var json = schema.Execute(_ =>
             {
                 _.Query = body.Query;
+                if (body.Variables != null)
+                    _.Inputs = body.Variables.ToString(Newtonsoft.Json.Formatting.None).ToInputs();
             });
-            return Ok(json);
+            return Ok(JObject.Parse(json));
         }
 
         [HttpGet("/blocks/")]

--- a/Libplanet.Explorer/ExplorerStartup.cs
+++ b/Libplanet.Explorer/ExplorerStartup.cs
@@ -35,7 +35,7 @@ namespace Libplanet.Explorer
             {
                 app.UseDeveloperExceptionPage();
             }
-
+            app.UseStaticFiles();
             app.UseMvc();
         }
     }


### PR DESCRIPTION
# Description

This patch adds [GraphiQL](https://github.com/graphql/graphiql) interface.

# How to use?

Run server and visit the `/graphiql.html` page

# Screenshot

![image](https://user-images.githubusercontent.com/276766/59776467-d29e3980-92ed-11e9-975e-9c1f799b21e7.png)
