### PR TITLE
Add wwwroot to ItemGroup

### DIFF
--- a/Libplanet.Explorer/Libplanet.Explorer.csproj
+++ b/Libplanet.Explorer/Libplanet.Explorer.csproj
@@ -18,4 +18,8 @@
   <ItemGroup>
     <EmbeddedResource Include="Views\**" />
   </ItemGroup>
+
+  <ItemGroup>
+    <None Include="wwwroot\*" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
This patch adds `wwwroot` ItemGroup to Libplanet.Explorer.csproj to include graphiql.html into build output.