### PR TITLE
Correct type names

### DIFF
--- a/Libplanet.Explorer/GraphTypes/ActionType.cs
+++ b/Libplanet.Explorer/GraphTypes/ActionType.cs
@@ -23,6 +23,8 @@ namespace Libplanet.Explorer.GraphTypes
                     return result;
                 }
             );
+
+            Name = "Action";
         }
     }
 }

--- a/Libplanet.Explorer/GraphTypes/BlockType.cs
+++ b/Libplanet.Explorer/GraphTypes/BlockType.cs
@@ -24,6 +24,8 @@ namespace Libplanet.Explorer.GraphTypes
             );
             Field(x => x.Timestamp);
             Field<ListGraphType<TransactionType<T>>>("transactions");
+
+            Name = "Block";
         }
     }
 }

--- a/Libplanet.Explorer/GraphTypes/BlocksQuery.cs
+++ b/Libplanet.Explorer/GraphTypes/BlocksQuery.cs
@@ -26,7 +26,9 @@ namespace Libplanet.Explorer.GraphTypes
                     return _chain.FirstOrDefault(x => (ulong)x.Index == index);
                 }
             );
+
             _chain = chain;
+            Name = "BlockQuery";
         }
     }
 }

--- a/Libplanet.Explorer/GraphTypes/TransactionType.cs
+++ b/Libplanet.Explorer/GraphTypes/TransactionType.cs
@@ -28,6 +28,8 @@ namespace Libplanet.Explorer.GraphTypes
             );
             Field(x => x.Timestamp);
             Field<ListGraphType<ActionType<T>>>("Actions");
+
+            Name = "Transaction";
         }
     }
 }


### PR DESCRIPTION
Since GraphQL.NET's automatic introspection generates invalid type names for generic types (e.g., <code>Block&#x60;1</code>), This patch configures type names manually.

This addresses the following error reported by #24:

```
Uncaught Error: Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "BlocksQuery`1" does not.
```