### PR TITLE
Turn on LiteDB readOnly option

### DIFF
--- a/Libplanet.Explorer.Executable/StoreRegistry.cs
+++ b/Libplanet.Explorer.Executable/StoreRegistry.cs
@@ -11,7 +11,7 @@ namespace Libplanet.Explorer.Executable
         private static (string, Parser)[] stores = new (string, Parser)[]
         {
             ("file", s => new FileStore(s)),
-            ("litedb", s => new LiteDBStore(s)),
+            ("litedb", s => new LiteDBStore(s, readOnly: true)),
         };
 
         private delegate IStore Parser(string connectionString);

--- a/Libplanet.Explorer/Libplanet.Explorer.csproj
+++ b/Libplanet.Explorer/Libplanet.Explorer.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="GraphQL" Version="2.4.0" />
-    <PackageReference Include="Libplanet" Version="0.5.0-nightly.20190806" />
+    <PackageReference Include="Libplanet" Version="0.5.0-dev.20190813150537" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.2.3" AllowExplicitVersion="true" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR bumps libplanet version to [0.5.0-dev.20190813150537](https://www.nuget.org/packages/Libplanet/0.5.0-dev.20190813150537) and turns on `readOnly` options for `LiteDBStore`.