### PR TITLE
Bump Libplanet version to 0.6.0

### DIFF
--- a/Libplanet.Explorer.Executable/Options.cs
+++ b/Libplanet.Explorer.Executable/Options.cs
@@ -77,11 +77,11 @@ If omitted (default) explorer only the local blockchain store.")]
                 byte[] pubkeyBytes = ByteUtil.ParseHex(parts[0]);
                 var pubkey = new PublicKey(pubkeyBytes);
                 var endpoint = new DnsEndPoint(parts[1], int.Parse(parts[2]));
-                Seed = new Peer(pubkey, endpoint);
+                Seed = new BoundPeer(pubkey, endpoint, 0);
             }
         }
 
-        public Peer Seed { get; set; }
+        public BoundPeer Seed { get; set; }
 
         [Option(
             'I',

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -48,7 +48,7 @@ namespace Libplanet.Explorer.Executable
             Startup.BlockChainSingleton = blockChain;
 
             Swarm<AppAgnosticAction> swarm = null;
-            if (options.Seed is Peer)
+            if (options.Seed is BoundPeer)
             {
                 // TODO: Take privateKey as a CLI option
                 // TODO: Take appProtocolVersion as a CLI option
@@ -100,17 +100,23 @@ namespace Libplanet.Explorer.Executable
                         peers.Add(peer);
                     }
 
-                    await swarm.AddPeersAsync(
+                    await swarm.BootstrapAsync(
                         peers,
+                        5000,
+                        5000,
                         cancellationToken: cts.Token
                     );
 
-                    ImmutableHashSet<Address> trustedPeers =
-                        peers.Select(p => p.Address).ToImmutableHashSet();
+                    // Since explorer does not require states, turn off trustedPeer option.
+                    /*ImmutableHashSet<Address> trustedPeers =
+                        peers.Select(p => p.Address).ToImmutableHashSet();*/
+                    var trustedPeers = ImmutableHashSet<Address>.Empty;
+                    Console.Error.WriteLine("Starts preloading.");
                     await swarm.PreloadAsync(
                         trustedStateValidators: trustedPeers,
                         cancellationToken: cts.Token
                     );
+                    Console.WriteLine("Finished preloading.");
 
                     await swarm.StartAsync(cancellationToken: cts.Token);
                 },

--- a/Libplanet.Explorer/Libplanet.Explorer.csproj
+++ b/Libplanet.Explorer/Libplanet.Explorer.csproj
@@ -26,7 +26,7 @@
       </IncludeAssets>
     </PackageReference>
     <PackageReference Include="GraphQL" Version="2.4.0" />
-    <PackageReference Include="Libplanet" Version="0.5.0" />
+    <PackageReference Include="Libplanet" Version="0.6.0" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.2.3" AllowExplicitVersion="true" />
   </ItemGroup>
 


### PR DESCRIPTION
Currently load states from trusted peers does not work, so temporarily disabled.