### PR TITLE
Automate build and push docker image

### DIFF
--- a/.github/workflows/push_docker_image.yml
+++ b/.github/workflows/push_docker_image.yml
@@ -1,0 +1,14 @@
+on: [push, pull_request]
+name: push docker image
+jobs:
+  build_and_push:
+    runs-on: ubuntu-16.04
+    steps:
+      - name: checkout
+        uses: actions/checkout@v1
+      - name: login
+        run: docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: build
+        run: docker build . -t ${{ secrets.DOCKER_USERNAME }}/libplanet-explorer:git-${{ github.sha }}
+      - name: push (publish)
+        run: docker push ${{ secrets.DOCKER_USERNAME }}/libplanet-explorer:git-${{ github.sha }}


### PR DESCRIPTION
In this pull-request, the process to build and push docker image, was automated with Github Actions.

It needs two secrets.
- DOCKER_USERNAME
- DOCKER_HUB_ACCESS_TOKEN

With these, it will build a image with tag *\<username\>/libplanet-explorer:git-\<sha\>* and will push to *Docker Hub*.

PS. you can get access token there, https://hub.docker.com/settings/security