### PR TITLE
Fix docker image username

### DIFF
--- a/.github/workflows/push_docker_image.yml
+++ b/.github/workflows/push_docker_image.yml
@@ -9,6 +9,6 @@ jobs:
       - name: login
         run: docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       - name: build
-        run: docker build . -t ${{ secrets.DOCKER_USERNAME }}/libplanet-explorer:git-${{ github.sha }}
+        run: docker build . -t planetariumhq/libplanet-explorer:git-${{ github.sha }}
       - name: push (publish)
-        run: docker push ${{ secrets.DOCKER_USERNAME }}/libplanet-explorer:git-${{ github.sha }}
+        run: docker push planetariumhq/libplanet-explorer:git-${{ github.sha }}


### PR DESCRIPTION
Before this, the username in tag, was changed by user logged in.
But it was fixed to *planetariumhq* because only *planetariumbot* will push the image.