### PR TITLE
Support memory mode

### DIFF
--- a/Libplanet.Explorer.Executable/Options.cs
+++ b/Libplanet.Explorer.Executable/Options.cs
@@ -124,7 +124,7 @@ If omitted (default) explorer only the local blockchain store.")]
         [Value(
             0,
             MetaName = "PATH",
-            Required = true,
+            Required = false,
             HelpText = "The path of the blockchain store.")]
         public string StorePath { get; set; }
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ script on the command-line:
 a Libplanet-powered game.  If you need a sample data file please contact us
 on [our Discord chat][1]!
 
+If you omit `BLOCKCHAIN_STORE_PATH` in online mode, explorer will use memory to store
+blockchain instead of storage.
+
 [.NET Core]: https://dotnet.microsoft.com/
 [PowerShell]: https://microsoft.com/PowerShell
 [1]: https://discord.gg/ue9fgc3


### PR DESCRIPTION
By omitting `BLOCKCHAIN_STORE_PATH`, explorer runs in 'in-memory' mode.