### PR TITLE
Fix casting bug on Address type.

### DIFF
--- a/Libplanet.Explorer/GraphTypes/AddressType.cs
+++ b/Libplanet.Explorer/GraphTypes/AddressType.cs
@@ -13,7 +13,12 @@ namespace Libplanet.Explorer.GraphTypes
 
         public override object Serialize(object value)
         {
-            return ((Address?)value)?.ToString();
+            if (value is Address addr)
+            {
+                return addr.ToString();
+            }
+
+            return value;
         }
 
         public override object ParseValue(object value)


### PR DESCRIPTION
Context: https://github.com/planetarium/libplanet-explorer-frontend/issues/9#issuecomment-546342040

This PR fixes a bug that `Address` type hadn't be parsed properly via Graphql variables.