### PR TITLE
Commandline argument now takes several seed peers

### DIFF
--- a/Libplanet.Explorer.Executable/Options.cs
+++ b/Libplanet.Explorer.Executable/Options.cs
@@ -44,8 +44,8 @@ namespace Libplanet.Explorer.Executable
         [Option(
             's',
             "seed",
-            HelpText = @"A seed node to join to the network as a node.
-The format is a comma-separated triple of a peer's hexadecimal public key, host, and port number.
+            HelpText = @"Seed nodes to join to the network as a node. The format of each
+seed is a comma-separated triple of a peer's hexadecimal public key, host, and port number.
 E.g., `02ed49dbe0f2c34d9dff8335d6dd9097f7a3ef17dfb5f048382eebc7f451a50aa1,example.com,31234'.
 If omitted (default) explorer only the local blockchain store.")]
         public IEnumerable<string> SeedStrings

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ on Linux, macOS, and Windows.  After you install them, execute the *run.ps1*
 script on the command-line:
 
 ~~~~ bash
-./run.ps1 BLOCKCHAIN_STORE_PATH
+./run.ps1 --store-path BLOCKCHAIN_STORE_PATH
 ~~~~
 
 `BLOCKCHAIN_STORE_PATH` refers to a directory or a file made by
 a Libplanet-powered game.  If you need a sample data file please contact us
 on [our Discord chat][1]!
 
-If you omit `BLOCKCHAIN_STORE_PATH` in online mode, explorer will use memory to store
+If you omit `--store-path` switch in online mode, explorer will use memory to store
 blockchain instead of storage.
 
 [.NET Core]: https://dotnet.microsoft.com/


### PR DESCRIPTION
By this patch, `BLOCKCHAIN_STORE_PATH` is no more argument. Use it with `--store-path` switch.