### PR TITLE
Introduce RichStore

### DIFF
--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -11,6 +11,7 @@ using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
 using Libplanet.Explorer.Interfaces;
+using Libplanet.Explorer.Store;
 using Libplanet.Net;
 using Libplanet.Store;
 using Microsoft.AspNetCore;
@@ -40,7 +41,7 @@ namespace Libplanet.Explorer.Executable
                 .WriteTo.Console();
             Log.Logger = loggerConfig.CreateLogger();
 
-            IStore store = new DefaultStore(
+            IStore store = new RichStore(
                 path: options.StorePath,
                 flush: false,
                 readOnly: options.Seeds is null

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -41,11 +41,24 @@ namespace Libplanet.Explorer.Executable
                 .WriteTo.Console();
             Log.Logger = loggerConfig.CreateLogger();
 
-            IStore store = new RichStore(
-                path: options.StorePath,
-                flush: false,
-                readOnly: options.Seeds is null
-            );
+            IStore store;
+            if (options.Seeds.Any())
+            {
+                store = new RichStore(
+                    path: options.StorePath,
+                    flush: false,
+                    readOnly: options.Seeds is null
+                );
+            }
+            else
+            {
+                store = new DefaultStore(
+                    path: options.StorePath,
+                    flush: false,
+                    readOnly: options.Seeds is null
+                );
+            }
+
             IBlockPolicy<AppAgnosticAction> policy = new BlockPolicy<AppAgnosticAction>(
                 null,
                 blockIntervalMilliseconds: options.BlockIntervalMilliseconds,

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -41,30 +41,23 @@ namespace Libplanet.Explorer.Executable
                 .WriteTo.Console();
             Log.Logger = loggerConfig.CreateLogger();
 
-            IStore store;
+            bool readOnlyMode = options.Seeds is null;
+
+            // Initialized DefaultStore.
+            IStore store = new DefaultStore(
+                path: options.StorePath,
+                flush: false,
+                readOnly: readOnlyMode
+            );
+
             if (options.Seeds.Any())
             {
-                // Initialized DefaultStore.
-                store = new DefaultStore(
-                    path: options.StorePath,
-                    flush: false,
-                    readOnly: options.Seeds is null
-                );
-
                 // Warp up store.
                 store = new RichStore(
                     store,
                     path: options.StorePath,
                     flush: false,
-                    readOnly: options.Seeds is null
-                );
-            }
-            else
-            {
-                store = new DefaultStore(
-                    path: options.StorePath,
-                    flush: false,
-                    readOnly: options.Seeds is null
+                    readOnly: readOnlyMode
                 );
             }
 

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -44,7 +44,16 @@ namespace Libplanet.Explorer.Executable
             IStore store;
             if (options.Seeds.Any())
             {
+                // Initialized DefaultStore.
+                store = new DefaultStore(
+                    path: options.StorePath,
+                    flush: false,
+                    readOnly: options.Seeds is null
+                );
+
+                // Warp up store.
                 store = new RichStore(
+                    store,
                     path: options.StorePath,
                     flush: false,
                     readOnly: options.Seeds is null

--- a/Libplanet.Explorer/Controllers/ExplorerController.cs
+++ b/Libplanet.Explorer/Controllers/ExplorerController.cs
@@ -41,6 +41,7 @@ namespace Libplanet.Explorer.Controllers
             {
                 _.UserContext = (BlockChain, Store);
                 _.Query = body.Query;
+                _.ThrowOnUnhandledException = true;
                 if (body.Variables != null)
                 {
                     _.Inputs = body.Variables.ToString(Newtonsoft.Json.Formatting.None).ToInputs();

--- a/Libplanet.Explorer/Controllers/ExplorerController.cs
+++ b/Libplanet.Explorer/Controllers/ExplorerController.cs
@@ -2,8 +2,8 @@ using GraphQL;
 using GraphQL.Types;
 using Libplanet.Action;
 using Libplanet.Blockchain;
-using Libplanet.Explorer.GraphTypes;
 using Libplanet.Explorer.Interfaces;
+using Libplanet.Store;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json.Linq;
 
@@ -24,6 +24,8 @@ namespace Libplanet.Explorer.Controllers
 
         public BlockChain<T> BlockChain => _context.BlockChain;
 
+        public IStore Store => _context.Store;
+
         [HttpGet("/")]
         public IActionResult GetRoot()
         {
@@ -37,7 +39,7 @@ namespace Libplanet.Explorer.Controllers
         {
             var json = _schema.Execute(_ =>
             {
-                _.UserContext = BlockChain;
+                _.UserContext = (BlockChain, Store);
                 _.Query = body.Query;
                 if (body.Variables != null)
                 {

--- a/Libplanet.Explorer/Controllers/ExplorerController.cs
+++ b/Libplanet.Explorer/Controllers/ExplorerController.cs
@@ -1,9 +1,7 @@
 using GraphQL;
 using GraphQL.Types;
 using Libplanet.Action;
-using Libplanet.Blockchain;
 using Libplanet.Explorer.Interfaces;
-using Libplanet.Store;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json.Linq;
 
@@ -22,10 +20,6 @@ namespace Libplanet.Explorer.Controllers
             _schema = context.GetSchema();
         }
 
-        public BlockChain<T> BlockChain => _context.BlockChain;
-
-        public IStore Store => _context.Store;
-
         [HttpGet("/")]
         public IActionResult GetRoot()
         {
@@ -39,7 +33,7 @@ namespace Libplanet.Explorer.Controllers
         {
             var json = _schema.Execute(_ =>
             {
-                _.UserContext = (BlockChain, Store);
+                _.UserContext = _context;
                 _.Query = body.Query;
                 _.ThrowOnUnhandledException = true;
                 if (body.Variables != null)

--- a/Libplanet.Explorer/GraphTypes/BlockType.cs
+++ b/Libplanet.Explorer/GraphTypes/BlockType.cs
@@ -1,8 +1,11 @@
+using System;
 using System.Security.Cryptography;
 using GraphQL.Types;
 using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blocks;
+using Libplanet.Explorer.Interfaces;
+using Libplanet.Store;
 
 namespace Libplanet.Explorer.GraphTypes
 {
@@ -22,7 +25,7 @@ namespace Libplanet.Explorer.GraphTypes
             Field<BlockType<T>>(
                 "PreviousBlock",
                 resolve: ctx => ctx.Source.PreviousHash is HashDigest<SHA256> h
-                    ? ((BlockChain<T>)ctx.UserContext)[h]
+                    ? ((Tuple<BlockChain<T>, IStore>)ctx.UserContext).Item1[h]
                     : null
             );
             Field(x => x.Timestamp);

--- a/Libplanet.Explorer/GraphTypes/BlockType.cs
+++ b/Libplanet.Explorer/GraphTypes/BlockType.cs
@@ -1,11 +1,8 @@
-using System;
 using System.Security.Cryptography;
 using GraphQL.Types;
 using Libplanet.Action;
-using Libplanet.Blockchain;
 using Libplanet.Blocks;
 using Libplanet.Explorer.Interfaces;
-using Libplanet.Store;
 
 namespace Libplanet.Explorer.GraphTypes
 {
@@ -25,7 +22,7 @@ namespace Libplanet.Explorer.GraphTypes
             Field<BlockType<T>>(
                 "PreviousBlock",
                 resolve: ctx => ctx.Source.PreviousHash is HashDigest<SHA256> h
-                    ? ((Tuple<BlockChain<T>, IStore>)ctx.UserContext).Item1[h]
+                    ? ((IBlockChainContext<T>)ctx.UserContext).BlockChain[h]
                     : null
             );
             Field(x => x.Timestamp);

--- a/Libplanet.Explorer/GraphTypes/TransactionType.cs
+++ b/Libplanet.Explorer/GraphTypes/TransactionType.cs
@@ -38,8 +38,9 @@ namespace Libplanet.Explorer.GraphTypes
                     var (chain, store) = (ValueTuple<BlockChain<T>, IStore>)ctx.UserContext;
                     if (store is RichStore richStore)
                     {
-                        return richStore.IterateTxReferences(ctx.Source.Id)
-                            .Select(blockHash => chain[blockHash]);
+                        return richStore
+                            .IterateTxReferences(ctx.Source.Id)
+                            .Select(r => chain[r.Item2]);
                     }
                     else
                     {

--- a/Libplanet.Explorer/GraphTypes/TransactionType.cs
+++ b/Libplanet.Explorer/GraphTypes/TransactionType.cs
@@ -1,11 +1,9 @@
-using System;
 using System.Linq;
 using GraphQL;
 using GraphQL.Types;
 using Libplanet.Action;
-using Libplanet.Blockchain;
+using Libplanet.Explorer.Interfaces;
 using Libplanet.Explorer.Store;
-using Libplanet.Store;
 using Libplanet.Tx;
 
 namespace Libplanet.Explorer.GraphTypes
@@ -35,12 +33,12 @@ namespace Libplanet.Explorer.GraphTypes
                 name: "BlockRef",
                 resolve: ctx =>
                 {
-                    var (chain, store) = (ValueTuple<BlockChain<T>, IStore>)ctx.UserContext;
-                    if (store is RichStore richStore)
+                    var blockChainContext = (IBlockChainContext<T>)ctx.UserContext;
+                    if (blockChainContext.Store is RichStore richStore)
                     {
                         return richStore
                             .IterateTxReferences(ctx.Source.Id)
-                            .Select(r => chain[r.Item2]);
+                            .Select(r => blockChainContext.BlockChain[r.Item2]);
                     }
                     else
                     {

--- a/Libplanet.Explorer/Queries/Query.cs
+++ b/Libplanet.Explorer/Queries/Query.cs
@@ -82,7 +82,7 @@ namespace Libplanet.Explorer.Queries
                 yield break;
             }
 
-            if (_store is RichStore richStore && !(signer is null && involved is null))
+            if (_store is RichStore richStore)
             {
                 IEnumerable<TxId> txIds;
                 if (!(signer is null))
@@ -91,11 +91,17 @@ namespace Libplanet.Explorer.Queries
                         .IterateSignerReferences(
                             (Address)signer, desc, (int)offset, limit ?? int.MaxValue);
                 }
-                else
+                else if (!(involved is null))
                 {
                     txIds = richStore
                         .IterateUpdatedAddressReferences(
                             (Address)involved, desc, (int)offset, limit ?? int.MaxValue);
+                }
+                else
+                {
+                    txIds = richStore
+                        .IterateTxReferences(null, desc, (int)offset, limit ?? int.MaxValue)
+                        .Select(r => r.Item1);
                 }
 
                 var txs = txIds.Select(txId => _chain.GetTransaction(txId));

--- a/Libplanet.Explorer/Store/AddressRefDoc.cs
+++ b/Libplanet.Explorer/Store/AddressRefDoc.cs
@@ -20,6 +20,6 @@ namespace Libplanet.Explorer.Store
 
         public TxId TxId { get; set; }
 
-        public DateTimeOffset Timestamp { get; set; }
+        public long TxNonce { get; set; }
     }
 }

--- a/Libplanet.Explorer/Store/AddressRefDoc.cs
+++ b/Libplanet.Explorer/Store/AddressRefDoc.cs
@@ -1,0 +1,25 @@
+using System;
+using Libplanet.Tx;
+using LiteDB;
+
+namespace Libplanet.Explorer.Store
+{
+    public class AddressRefDoc
+    {
+        [BsonId]
+        public string Id => AddressString + "_" + TxId.ToHex();
+
+        public string AddressString { get; set; }
+
+        [BsonIgnore]
+        public Address Address
+        {
+            get => new Address(AddressString);
+            set { AddressString = value.ToString(); }
+        }
+
+        public TxId TxId { get; set; }
+
+        public DateTimeOffset Timestamp { get; set; }
+    }
+}

--- a/Libplanet.Explorer/Store/AddressRefDoc.cs
+++ b/Libplanet.Explorer/Store/AddressRefDoc.cs
@@ -15,7 +15,7 @@ namespace Libplanet.Explorer.Store
         public Address Address
         {
             get => new Address(AddressString);
-            set { AddressString = value.ToString(); }
+            set { AddressString = value.ToHex().ToLowerInvariant(); }
         }
 
         public TxId TxId { get; set; }

--- a/Libplanet.Explorer/Store/AddressRefDoc.cs
+++ b/Libplanet.Explorer/Store/AddressRefDoc.cs
@@ -4,7 +4,7 @@ using LiteDB;
 
 namespace Libplanet.Explorer.Store
 {
-    public class AddressRefDoc
+    internal class AddressRefDoc
     {
         [BsonId]
         public string Id => AddressString + "_" + TxId.ToHex();

--- a/Libplanet.Explorer/Store/IRichStore.cs
+++ b/Libplanet.Explorer/Store/IRichStore.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using Libplanet.Store;
+using Libplanet.Tx;
+
+namespace Libplanet.Explorer.Store
+{
+    public interface IRichStore : IStore
+    {
+        void StoreTxReferences(TxId txId, HashDigest<SHA256> blockHash, long blockIndex);
+
+        IEnumerable<ValueTuple<TxId, HashDigest<SHA256>>> IterateTxReferences(
+            TxId? txId = null,
+            bool desc = false,
+            int offset = 0,
+            int limit = int.MaxValue);
+
+        void StoreSignerReferences(TxId txId, long txNonce, Address signer);
+
+        IEnumerable<TxId> IterateSignerReferences(
+            Address signer,
+            bool desc,
+            int offset = 0,
+            int limit = int.MaxValue);
+
+        void StoreUpdatedAddressReferences(
+            TxId txId,
+            long txNonce,
+            Address updatedAddress);
+
+        IEnumerable<TxId> IterateUpdatedAddressReferences(
+            Address updatedAddress,
+            bool desc,
+            int offset = 0,
+            int limit = int.MaxValue);
+    }
+}

--- a/Libplanet.Explorer/Store/RichStore.cs
+++ b/Libplanet.Explorer/Store/RichStore.cs
@@ -7,6 +7,7 @@ using Libplanet.Blocks;
 using Libplanet.Store;
 using Libplanet.Tx;
 using LiteDB;
+using Serilog;
 using FileMode = LiteDB.FileMode;
 
 namespace Libplanet.Explorer.Store
@@ -90,8 +91,6 @@ namespace Libplanet.Explorer.Store
         {
             var collection = TxRefCollection();
             collection.Upsert(new TxRefDoc { TxId = txId, BlockHash = blockHash });
-            Console.WriteLine(
-                $"{nameof(StoreTxReferences)} | {txId.ToHex()} - {blockHash.ToString()}");
         }
 
         public IEnumerable<HashDigest<SHA256>> IterateTxReferences(TxId txId)
@@ -111,8 +110,6 @@ namespace Libplanet.Explorer.Store
             {
                 Address = signer, Timestamp = timestamp, TxId = txId,
             });
-            Console.WriteLine(
-                $"{nameof(StoreSignerReferences)} | {txId.ToHex()} - {signer.ToHex()}");
         }
 
         public IEnumerable<TxId> IterateSignerReferences(Address signer, bool desc)
@@ -140,9 +137,6 @@ namespace Libplanet.Explorer.Store
             {
                 Address = updatedAddress, Timestamp = timestamp, TxId = txId,
             });
-            Console.WriteLine(
-                $"{nameof(StoreUpdatedAddressReferences)} | {txId.ToHex()} - " +
-                $"{updatedAddress.ToHex()}");
         }
 
         public IEnumerable<TxId> IterateUpdatedAddressReferences(

--- a/Libplanet.Explorer/Store/RichStore.cs
+++ b/Libplanet.Explorer/Store/RichStore.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using Libplanet.Blocks;
@@ -122,10 +123,7 @@ namespace Libplanet.Explorer.Store
                 );
             }
 
-            foreach (var doc in collection.Find(query, offset, limit))
-            {
-                yield return (doc.TxId, doc.BlockHash);
-            }
+            return collection.Find(query, offset, limit).Select(doc => (doc.TxId, doc.BlockHash));
         }
 
         public void StoreSignerReferences(TxId txId, long txNonce, Address signer)
@@ -152,10 +150,7 @@ namespace Libplanet.Explorer.Store
                 Query.All(nameof(AddressRefDoc.TxNonce), order),
                 Query.EQ(nameof(AddressRefDoc.AddressString), addressString)
             );
-            foreach (var doc in collection.Find(query, offset, limit))
-            {
-                yield return doc.TxId;
-            }
+            return collection.Find(query, offset, limit).Select(doc => doc.TxId);
         }
 
         public void StoreUpdatedAddressReferences(
@@ -185,10 +180,7 @@ namespace Libplanet.Explorer.Store
                 Query.All(nameof(AddressRefDoc.TxNonce), order),
                 Query.EQ(nameof(AddressRefDoc.AddressString), addressString)
             );
-            foreach (var doc in collection.Find(query, offset, limit))
-            {
-                yield return doc.TxId;
-            }
+            return collection.Find(query, offset, limit).Select(doc => doc.TxId);
         }
 
         private LiteCollection<TxRefDoc> TxRefCollection() =>

--- a/Libplanet.Explorer/Store/RichStore.cs
+++ b/Libplanet.Explorer/Store/RichStore.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using Libplanet.Blocks;
+using Libplanet.Store;
+using Libplanet.Tx;
+using LiteDB;
+using FileMode = LiteDB.FileMode;
+
+namespace Libplanet.Explorer.Store
+{
+    public class RichStore : DefaultStore
+    {
+        private const string TxRefCollectionName = "block_ref";
+        private const string SignerRefCollectionName = "signer_ref";
+        private const string UpdatedAddressRefCollectionName = "updated_address_ref";
+
+        private readonly MemoryStream _memoryStream;
+        private readonly LiteDatabase _db;
+
+        /// <inheritdoc cref="DefaultStore"/>
+        public RichStore(
+            string path,
+            bool compress = false,
+            bool journal = true,
+            int indexCacheSize = 50000,
+            int blockCacheSize = 512,
+            int txCacheSize = 1024,
+            int statesCacheSize = 10000,
+            bool flush = true,
+            bool readOnly = false)
+            : base(
+                path,
+                compress,
+                journal,
+                indexCacheSize,
+                blockCacheSize,
+                txCacheSize,
+                statesCacheSize,
+                flush,
+                readOnly)
+        {
+            if (path is null)
+            {
+                _memoryStream = new MemoryStream();
+                _db = new LiteDatabase(_memoryStream);
+            }
+            else
+            {
+                var connectionString = new ConnectionString
+                {
+                    Filename = Path.Combine(path, "ext.ldb"),
+                    Journal = journal,
+                    CacheSize = indexCacheSize,
+                    Flush = flush,
+                };
+
+                if (readOnly)
+                {
+                    connectionString.Mode = FileMode.ReadOnly;
+                }
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) &&
+                         Type.GetType("Mono.Runtime") is null)
+                {
+                    // macOS + .NETCore doesn't support shared lock.
+                    connectionString.Mode = FileMode.Exclusive;
+                }
+
+                _db = new LiteDatabase(connectionString);
+            }
+        }
+
+        public override void PutBlock<T>(Block<T> block)
+        {
+            base.PutBlock(block);
+            foreach (var tx in block.Transactions)
+            {
+                StoreTxReferences(tx.Id, block.Hash);
+                StoreSignerReferences(tx.Id, tx.Timestamp, tx.Signer);
+                foreach (var updatedAddress in tx.UpdatedAddresses)
+                {
+                    StoreUpdatedAddressReferences(tx.Id, tx.Timestamp, updatedAddress);
+                }
+            }
+        }
+
+        public void StoreTxReferences(TxId txId, HashDigest<SHA256> blockHash)
+        {
+            var collection = TxRefCollection();
+            collection.Upsert(new TxRefDoc { TxId = txId, BlockHash = blockHash });
+            Console.WriteLine(
+                $"{nameof(StoreTxReferences)} | {txId.ToHex()} - {blockHash.ToString()}");
+        }
+
+        public IEnumerable<HashDigest<SHA256>> IterateTxReferences(TxId txId)
+        {
+            var collection = TxRefCollection();
+            var query = Query.EQ(nameof(TxRefDoc.TxId), txId.ToByteArray());
+            foreach (var doc in collection.Find(query))
+            {
+                yield return doc.BlockHash;
+            }
+        }
+
+        public void StoreSignerReferences(TxId txId, DateTimeOffset timestamp, Address signer)
+        {
+            var collection = SignerRefCollection();
+            collection.Upsert(new AddressRefDoc
+            {
+                Address = signer, Timestamp = timestamp, TxId = txId,
+            });
+            Console.WriteLine(
+                $"{nameof(StoreSignerReferences)} | {txId.ToHex()} - {signer.ToHex()}");
+        }
+
+        public IEnumerable<TxId> IterateSignerReferences(Address signer, bool desc)
+        {
+            var collection = SignerRefCollection();
+            var order = desc ? Query.Descending : Query.Ascending;
+            var addressString = signer.ToHex().ToLowerInvariant();
+            var query = Query.And(
+                Query.EQ(nameof(AddressRefDoc.AddressString), addressString),
+                Query.All(nameof(AddressRefDoc.Timestamp), order)
+            );
+            foreach (var doc in collection.Find(query))
+            {
+                yield return doc.TxId;
+            }
+        }
+
+        public void StoreUpdatedAddressReferences(
+            TxId txId,
+            DateTimeOffset timestamp,
+            Address updatedAddress)
+        {
+            var collection = UpdatedAddressRefCollection();
+            collection.Upsert(new AddressRefDoc
+            {
+                Address = updatedAddress, Timestamp = timestamp, TxId = txId,
+            });
+            Console.WriteLine(
+                $"{nameof(StoreUpdatedAddressReferences)} | {txId.ToHex()} - " +
+                $"{updatedAddress.ToHex()}");
+        }
+
+        public IEnumerable<TxId> IterateUpdatedAddressReferences(
+            Address updatedAddress,
+            bool desc)
+        {
+            var collection = UpdatedAddressRefCollection();
+            var order = desc ? Query.Descending : Query.Ascending;
+            var addressString = updatedAddress.ToHex().ToLowerInvariant();
+            var query = Query.And(
+                Query.EQ(nameof(AddressRefDoc.AddressString), addressString),
+                Query.All(nameof(AddressRefDoc.Timestamp), order)
+            );
+            foreach (var doc in collection.Find(query))
+            {
+                yield return doc.TxId;
+            }
+        }
+
+        private LiteCollection<TxRefDoc> TxRefCollection() =>
+            _db.GetCollection<TxRefDoc>(TxRefCollectionName);
+
+        private LiteCollection<AddressRefDoc> SignerRefCollection() =>
+            _db.GetCollection<AddressRefDoc>(SignerRefCollectionName);
+
+        private LiteCollection<AddressRefDoc> UpdatedAddressRefCollection() =>
+            _db.GetCollection<AddressRefDoc>(UpdatedAddressRefCollectionName);
+    }
+}

--- a/Libplanet.Explorer/Store/TxRefDoc.cs
+++ b/Libplanet.Explorer/Store/TxRefDoc.cs
@@ -1,0 +1,16 @@
+using System.Security.Cryptography;
+using Libplanet.Tx;
+using LiteDB;
+
+namespace Libplanet.Explorer.Store
+{
+    internal class TxRefDoc
+    {
+        [BsonId]
+        public string Id => TxId + "_" + BlockHash;
+
+        public HashDigest<SHA256> BlockHash { get; set; }
+
+        public TxId TxId { get; set; }
+    }
+}

--- a/Libplanet.Explorer/Store/TxRefDoc.cs
+++ b/Libplanet.Explorer/Store/TxRefDoc.cs
@@ -11,6 +11,8 @@ namespace Libplanet.Explorer.Store
 
         public HashDigest<SHA256> BlockHash { get; set; }
 
+        public long BlockIndex { get; set; }
+
         public TxId TxId { get; set; }
     }
 }


### PR DESCRIPTION
In this PR, it introduces `RichStore`, `IStore` implementation extended `DefaultStore`.
It works like `DefaultStore`, but it stores metadata like below, to search fast on `PutBlock`, `PutTransaction`.

- Transaction → Block
- Signer → Transaction
- UpdatedAddress → Transaction

By them, you can see the block a transaction is included through `blockRef` field.

![image](https://user-images.githubusercontent.com/26626194/73446263-c9a33980-439f-11ea-8405-59b8da37c92f.png)

Also listing transactions will be fast because it skips empty blocks and iterate only transactions directly. In my laptop environment, it takes just half. Of course, it can be slow in this structure if there was no empty block.

PS. it became to throw exceptions from GraphQL logic. 7f6ecf3 