### PR TITLE
Support Libplanet.RocksDB implementation

### DIFF
--- a/Libplanet.Explorer.Executable/Exceptions/InvalidOptionValueException.cs
+++ b/Libplanet.Explorer.Executable/Exceptions/InvalidOptionValueException.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Libplanet.Explorer.Executable.Exceptions
+{
+    public class InvalidOptionValueException : Exception
+    {
+        public InvalidOptionValueException(
+            string optionName,
+            string optionValue,
+            string[] expectedValues)
+        {
+            OptionName = optionName;
+            OptionValue = optionValue;
+            ExpectedValues = expectedValues;
+        }
+
+        public string OptionName { get; }
+
+        public string OptionValue { get; }
+
+        public string[] ExpectedValues { get; }
+    }
+}

--- a/Libplanet.Explorer.Executable/Options.cs
+++ b/Libplanet.Explorer.Executable/Options.cs
@@ -131,6 +131,14 @@ in memory version is used.")]
         public string StorePath { get; set; }
 
         [Option(
+            'T',
+            "store-type",
+            Default = null,
+            HelpText = @"The type of the blockchain store. If omitted (default)
+in DefaultStore is used.")]
+        public string StoreType { get; set; }
+
+        [Option(
             'G',
             "genesis-block",
             HelpText = "The path of the genesis block. It should be absolute or http url.",

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -136,7 +136,7 @@ namespace Libplanet.Explorer.Executable
             IStore store;
             if (options.Seeds.Any())
             {
-                // Wrap up store.
+                // Wrap up store to use more useful features.
                 store = new RichStore(
                     innerStore,
                     path: options.StorePath,
@@ -146,6 +146,8 @@ namespace Libplanet.Explorer.Executable
             }
             else
             {
+                // If there were no given seeds,
+                // use the store directly.
                 store = innerStore;
             }
 

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -119,29 +119,34 @@ namespace Libplanet.Explorer.Executable
         private static IStore LoadStore(Options options)
         {
             bool readOnlyMode = options.Seeds is null;
-            IStore store;
+            IStore innerStore;
             switch (options.StoreType)
             {
                 case "rocksdb":
-                    store = new RocksDBStore.RocksDBStore(options.StorePath);
+                    innerStore = new RocksDBStore.RocksDBStore(options.StorePath);
                     break;
                 default:
-                    store = new DefaultStore(
+                    innerStore = new DefaultStore(
                         options.StorePath,
                         flush: false,
                         readOnly: readOnlyMode);
                     break;
             }
 
+            IStore store;
             if (options.Seeds.Any())
             {
-                // Warp up store.
+                // Wrap up store.
                 store = new RichStore(
-                    store,
+                    innerStore,
                     path: options.StorePath,
                     flush: false,
                     readOnly: readOnlyMode
                 );
+            }
+            else
+            {
+                store = innerStore;
             }
 
             return store;

--- a/Libplanet.Explorer/Libplanet.Explorer.csproj
+++ b/Libplanet.Explorer/Libplanet.Explorer.csproj
@@ -27,6 +27,7 @@
     </PackageReference>
     <PackageReference Include="GraphQL" Version="2.4.0" />
     <PackageReference Include="Libplanet" Version="0.10.0-dev.20200626124654" />
+    <PackageReference Include="Libplanet.RocksDBStore" Version="0.10.0-dev.20200626124654" />
     <FrameworkReference Include="Microsoft.AspNetCore.App"/>
   </ItemGroup>
 


### PR DESCRIPTION
It resolves a part of #97 by supporting [Libplanet.RocksDB][libplanet-rocksdb] implementation.

Sadly, there is a problem that the execution with `dotnet run ~` doesn't work, but fortunately, it works with `dotnet Libplanet.Explorer.Explorer.dll ~`.  I wonder it's a problem only in my environment. I left also the [log][libplanet-rocksdb-dll-error].

Therefore I opened this pull request as a draft. If the problem was resolved or it was okay to not work with this, I will turn its state to *Ready for review*.

[libplanet-rocksdb]: https://github.com/planetarium/libplanet/tree/master/Libplanet.RocksDBStore
[libplanet-rocksdb-dll-error]: https://gist.github.com/moreal/66f82c673adf65e529031840ac5b93db