### PR TITLE
Bump .NET Core SDK version to 3.1.302 in GitHub Actions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,6 +7,6 @@ jobs:
     - uses: actions/checkout@master
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '2.2.103'
+        dotnet-version: '3.1.302'
     - run: dotnet build
     - run: dotnet test

--- a/Libplanet.Explorer.Executable/Libplanet.Explorer.Executable.csproj
+++ b/Libplanet.Explorer.Executable/Libplanet.Explorer.Executable.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <LangVersion>7.2</LangVersion>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU1701,SA1118</NoWarn>
     <CodeAnalysisRuleSet>..\Libplanet.Explorer.ruleset</CodeAnalysisRuleSet>

--- a/Libplanet.Explorer.UnitTests/Libplanet.Explorer.UnitTests.csproj
+++ b/Libplanet.Explorer.UnitTests/Libplanet.Explorer.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
         <IsPublishable>false</IsPublishable>

--- a/Libplanet.Explorer/ExplorerStartup.cs
+++ b/Libplanet.Explorer/ExplorerStartup.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace Libplanet.Explorer
 {
@@ -37,7 +38,7 @@ namespace Libplanet.Explorer
             services.AddSingleton<IBlockChainContext<T>, TU>();
         }
 
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             if (env.IsDevelopment())
             {

--- a/Libplanet.Explorer/Libplanet.Explorer.csproj
+++ b/Libplanet.Explorer/Libplanet.Explorer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <LangVersion>7.2</LangVersion>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Libplanet.Explorer</RootNamespace>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU1701</NoWarn>
@@ -27,7 +27,7 @@
     </PackageReference>
     <PackageReference Include="GraphQL" Version="2.4.0" />
     <PackageReference Include="Libplanet" Version="0.10.0-dev.20200626124654" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.2.3" AllowExplicitVersion="true" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Now, the latest .NET Core LTS release version is  .NET Core 3.1.302 release. To compare with another version, you can see on this [link][dotnet-core-download-link].

In this pull request, it bumps the .NET Core SDK's version used in GitHub Actions *on pull request* workflow to *3.1.302*.

https://dotnet.microsoft.com/download/dotnet-core/3.1

[dotnet-core-download-link]: https://dotnet.microsoft.com/download/dotnet-core