### PR TITLE
Migrate ASP.NET 3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,16 +9,21 @@ RUN dotnet restore Libplanet.Explorer.Executable
 
 # Copy everything else and build
 COPY . ./
-RUN dotnet publish -c Release -r linux-x64 -o out --self-contained
-RUN cp -r ./Libplanet.Explorer.Executable/wwwroot ./
+RUN dotnet publish -c Release -r linux-x64 -o out
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/core/runtime:3.1
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
 WORKDIR /app
-COPY --from=build-env /app/ .
+COPY --from=build-env /app/out .
+
+# Install native deps
+RUN apt-get update \
+    && apt-get install -y --allow-unauthenticated \
+        libc6-dev \
+     && rm -rf /var/lib/apt/lists/*
 
 # Runtime settings
 EXPOSE 5000
 VOLUME /data
 
-ENTRYPOINT ["dotnet", "Libplanet.Explorer.Executable/out/Libplanet.Explorer.Executable.dll"]
+ENTRYPOINT ["Libplanet.Explorer.Executable"]

--- a/Libplanet.Explorer.Executable/Libplanet.Explorer.Executable.csproj
+++ b/Libplanet.Explorer.Executable/Libplanet.Explorer.Executable.csproj
@@ -34,4 +34,9 @@
     <ProjectReference
       Include="..\Libplanet.Explorer\Libplanet.Explorer.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="wwwroot\**\*">
+      <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+    </Content>
+</ItemGroup>
 </Project>

--- a/Libplanet.Explorer/ExplorerStartup.cs
+++ b/Libplanet.Explorer/ExplorerStartup.cs
@@ -31,10 +31,11 @@ namespace Libplanet.Explorer
                             .AllowAnyHeader()
                 )
             );
-            services.AddMvc()
+            services.AddControllers()
                 .ConfigureApplicationPartManager(p =>
                     p.FeatureProviders.Add(
-                        new GenericControllerFeatureProvider<T>()));
+                        new GenericControllerFeatureProvider<T>()))
+                .AddNewtonsoftJson();
             services.AddSingleton<IBlockChainContext<T>, TU>();
         }
 
@@ -47,7 +48,11 @@ namespace Libplanet.Explorer
 
             app.UseStaticFiles();
             app.UseCors("AllowAllOrigins");
-            app.UseMvc();
+            app.UseRouting();
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+            });
         }
     }
 }

--- a/Libplanet.Explorer/Libplanet.Explorer.csproj
+++ b/Libplanet.Explorer/Libplanet.Explorer.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.6" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-beta.61">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>
@@ -28,7 +29,7 @@
     <PackageReference Include="GraphQL" Version="2.4.0" />
     <PackageReference Include="Libplanet" Version="0.10.0-dev.20200721083957" />
     <PackageReference Include="Libplanet.RocksDBStore" Version="0.10.0-dev.20200721083957" />
-    <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR migrates some codes related to ASP.NET for 3.1. 

And, it also adjusts Dockerfile to supporting RocksDB properly