### PR TITLE
Bypass difficulty

### DIFF
--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -201,21 +201,7 @@ namespace Libplanet.Explorer.Executable
             await swarm.PreloadAsync(
                 dialTimeout: TimeSpan.FromSeconds(15),
                 trustedStateValidators: trustedPeers,
-                cancellationToken: cancellationToken,
-                blockDownloadFailed: (obj, args) =>
-                {
-                    foreach (var exception in args.InnerExceptions)
-                    {
-                        if (exception is InvalidGenesisBlockException invalidGenesisBlockException)
-                        {
-                            Log.Error(
-                                "It seems you use different genesis block with the network. " +
-                                "The hash stored was {Stored} but network was {Network}",
-                                invalidGenesisBlockException.Stored.ToString(),
-                                invalidGenesisBlockException.NetworkExpected.ToString());
-                        }
-                    }
-                }
+                cancellationToken: cancellationToken
             );
             Console.WriteLine("Finished preloading.");
 
@@ -233,9 +219,11 @@ namespace Libplanet.Explorer.Executable
 
             public IAction BlockAction => _impl.BlockAction;
 
-            public bool DoesTransactionFollowsPolicy(Transaction<AppAgnosticAction> transaction)
+            public bool DoesTransactionFollowsPolicy(
+                Transaction<AppAgnosticAction> transaction, BlockChain<AppAgnosticAction> blockChain
+            )
             {
-                return _impl.DoesTransactionFollowsPolicy(transaction);
+                return _impl.DoesTransactionFollowsPolicy(transaction, blockChain);
             }
 
             public long GetNextBlockDifficulty(BlockChain<AppAgnosticAction> blocks)

--- a/Libplanet.Explorer/Libplanet.Explorer.csproj
+++ b/Libplanet.Explorer/Libplanet.Explorer.csproj
@@ -27,8 +27,8 @@
       </IncludeAssets>
     </PackageReference>
     <PackageReference Include="GraphQL" Version="2.4.0" />
-    <PackageReference Include="Libplanet" Version="0.10.0-dev.20200916074917" />
-    <PackageReference Include="Libplanet.RocksDBStore" Version="0.10.0-dev.20200916074917" />
+    <PackageReference Include="Libplanet" Version="0.10.0-dev.20200925085741" />
+    <PackageReference Include="Libplanet.RocksDBStore" Version="0.10.0-dev.20200925085741" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR causes the blockchain to ignore the difficulty check, allowing blocks of different difficulty levels on the chain.

It's a short-term solution for applications that control difficulty, and fundamentally it is necessary to integrate block policy of these applications.