### PR TITLE
feat: support stateRootHash field

### DIFF
--- a/Libplanet.Explorer.UnitTests/Common/Action/NoOpAction.cs
+++ b/Libplanet.Explorer.UnitTests/Common/Action/NoOpAction.cs
@@ -3,7 +3,7 @@ using Libplanet.Action;
 
 namespace Libplanet.Explorer.UnitTests.Common.Action
 {
-    public class NopeAction : IAction
+    public class NoOpAction : IAction
     {
         public void LoadPlainValue(IValue plainValue)
         {

--- a/Libplanet.Explorer.UnitTests/Common/Action/NopeAction.cs
+++ b/Libplanet.Explorer.UnitTests/Common/Action/NopeAction.cs
@@ -1,0 +1,17 @@
+using Bencodex.Types;
+using Libplanet.Action;
+
+namespace Libplanet.Explorer.UnitTests.Common.Action
+{
+    public class NopeAction : IAction
+    {
+        public void LoadPlainValue(IValue plainValue)
+        {
+        }
+
+        public IAccountStateDelta Execute(IActionContext context)
+            => context.PreviousStates;
+
+        public IValue PlainValue => default(Null);
+    }
+}

--- a/Libplanet.Explorer.UnitTests/GraphQLTestUtils.cs
+++ b/Libplanet.Explorer.UnitTests/GraphQLTestUtils.cs
@@ -1,0 +1,25 @@
+using System.Threading.Tasks;
+using GraphQL;
+using GraphQL.Types;
+
+namespace Libplanet.Explorer.UnitTests
+{
+    public static class GraphQLTestUtils
+    {
+        public static Task<ExecutionResult> ExecuteQueryAsync<TObjectGraphType>(string query, object userContext = null, object source = null)
+            where TObjectGraphType : IObjectGraphType, new()
+        {
+            var documentExecutor = new DocumentExecuter();
+            return documentExecutor.ExecuteAsync(new ExecutionOptions
+            {
+                Query = query,
+                Schema = new Schema
+                {
+                    Query = new TObjectGraphType(),
+                },
+                UserContext = userContext,
+                Root = source,
+            });
+        }
+    }
+}

--- a/Libplanet.Explorer.UnitTests/GraphTypes/BlockTypeTest.cs
+++ b/Libplanet.Explorer.UnitTests/GraphTypes/BlockTypeTest.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Security.Cryptography;
+using GraphQL;
+using GraphQL.Types;
+using Libplanet.Blocks;
+using Libplanet.Explorer.GraphTypes;
+using Libplanet.Explorer.UnitTests.Common.Action;
+using Libplanet.Tx;
+using Xunit;
+using static Libplanet.Explorer.UnitTests.GraphQLTestUtils;
+
+namespace Libplanet.Explorer.UnitTests.GraphTypes
+{
+    public class BlockTypeTest
+    {
+        [Fact]
+        public async void Query()
+        {
+            var block = new Block<NopeAction>(
+                1,
+                1,
+                1,
+                new Nonce(new byte[] {0x01, 0x23, 0x45, 0x56}),
+                new Address(TestUtils.GetRandomBytes(Address.Size)),
+                new HashDigest<SHA256>(TestUtils.GetRandomBytes(HashDigest<SHA256>.Size)),
+                DateTimeOffset.UtcNow,
+                ImmutableHashSet<Transaction<NopeAction>>.Empty,
+                stateRootHash: new HashDigest<SHA256>(
+                    TestUtils.GetRandomBytes(HashDigest<SHA256>.Size)));
+            var query =
+                @"{
+                    index
+                    hash
+                    nonce
+                    difficulty
+                    miner
+                    timestamp
+                    stateRootHash
+                }";
+
+            ExecutionResult result =
+                await ExecuteQueryAsync<BlockType<NopeAction>>(query, source: block);
+            Assert.Null(result.Errors);
+            Assert.Equal(
+                block.Index,
+                Convert.ToInt64(((Dictionary<string, object>) result.Data)["index"]));
+            Assert.Equal(
+                ByteUtil.Hex(block.Hash.ToByteArray()),
+                ((Dictionary<string, object>) result.Data)["hash"]);
+            Assert.Equal(
+                block.Difficulty,
+                Convert.ToInt64(((Dictionary<string, object>) result.Data)["difficulty"]));
+            Assert.Equal(
+                block.Miner?.ToString(),
+                ((Dictionary<string, object>) result.Data)["miner"]);
+            Assert.Equal(
+                ByteUtil.Hex(block.Nonce.ToByteArray()),
+                ((Dictionary<string, object>) result.Data)["nonce"]);
+            Assert.Equal(
+                new DateTimeOffsetGraphType().Serialize(block.Timestamp),
+                ((Dictionary<string, object>) result.Data)["timestamp"]);
+            Assert.Equal(
+                ByteUtil.Hex(block.StateRootHash?.ToByteArray()),
+                ((Dictionary<string, object>) result.Data)["stateRootHash"]);
+        }
+    }
+}

--- a/Libplanet.Explorer.UnitTests/GraphTypes/BlockTypeTest.cs
+++ b/Libplanet.Explorer.UnitTests/GraphTypes/BlockTypeTest.cs
@@ -18,7 +18,7 @@ namespace Libplanet.Explorer.UnitTests.GraphTypes
         [Fact]
         public async void Query()
         {
-            var block = new Block<NopeAction>(
+            var block = new Block<NoOpAction>(
                 1,
                 1,
                 1,
@@ -26,7 +26,7 @@ namespace Libplanet.Explorer.UnitTests.GraphTypes
                 new Address(TestUtils.GetRandomBytes(Address.Size)),
                 new HashDigest<SHA256>(TestUtils.GetRandomBytes(HashDigest<SHA256>.Size)),
                 DateTimeOffset.UtcNow,
-                ImmutableHashSet<Transaction<NopeAction>>.Empty,
+                ImmutableHashSet<Transaction<NoOpAction>>.Empty,
                 stateRootHash: new HashDigest<SHA256>(
                     TestUtils.GetRandomBytes(HashDigest<SHA256>.Size)));
             var query =
@@ -41,7 +41,7 @@ namespace Libplanet.Explorer.UnitTests.GraphTypes
                 }";
 
             ExecutionResult result =
-                await ExecuteQueryAsync<BlockType<NopeAction>>(query, source: block);
+                await ExecuteQueryAsync<BlockType<NoOpAction>>(query, source: block);
             Assert.Null(result.Errors);
             Assert.Equal(
                 block.Index,

--- a/Libplanet.Explorer.UnitTests/TestUtils.cs
+++ b/Libplanet.Explorer.UnitTests/TestUtils.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Libplanet.Explorer.UnitTests
+{
+    public static class TestUtils
+    {
+        private static readonly Random _random;
+
+        static TestUtils()
+        {
+            _random = new Random();
+        }
+
+        public static byte[] GetRandomBytes(int size)
+        {
+            var bytes = new byte[size];
+            _random.NextBytes(bytes);
+            return bytes;
+        }
+
+        public static int GetRandomNumber() => _random.Next();
+    }
+}

--- a/Libplanet.Explorer/GraphTypes/BlockType.cs
+++ b/Libplanet.Explorer/GraphTypes/BlockType.cs
@@ -26,6 +26,9 @@ namespace Libplanet.Explorer.GraphTypes
                     : null
             );
             Field(x => x.Timestamp);
+            Field<ByteStringType>(
+                "StateRootHash",
+                resolve: ctx => ctx.Source.StateRootHash?.ToByteArray());
             Field<NonNullGraphType<ListGraphType<NonNullGraphType<TransactionType<T>>>>>(
                 "transactions"
             );


### PR DESCRIPTION
The field of `Block<T>`, `StateRootHash` has been since planetarium/libplanet#939. But there was no way to see it and I made this project support it. And, other fields have also been not supported until now (e.g., total difficulty). It seems to need following up planetarium/libplanet's updates in other pull requests.