### PR TITLE
feat: support totalDifficulty field

### DIFF
--- a/Libplanet.Explorer.UnitTests/GraphQLTestUtils.cs
+++ b/Libplanet.Explorer.UnitTests/GraphQLTestUtils.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using GraphQL;
 using GraphQL.Types;
@@ -6,7 +7,10 @@ namespace Libplanet.Explorer.UnitTests
 {
     public static class GraphQLTestUtils
     {
-        public static Task<ExecutionResult> ExecuteQueryAsync<TObjectGraphType>(string query, object userContext = null, object source = null)
+        public static Task<ExecutionResult> ExecuteQueryAsync<TObjectGraphType>(
+            string query,
+            IDictionary<string, object> userContext = null,
+            object source = null)
             where TObjectGraphType : IObjectGraphType, new()
         {
             var documentExecutor = new DocumentExecuter();

--- a/Libplanet.Explorer.UnitTests/GraphTypes/ActionArgumentTypeTest.cs
+++ b/Libplanet.Explorer.UnitTests/GraphTypes/ActionArgumentTypeTest.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GraphQL;
+using Libplanet.Explorer.GraphTypes;
+using Xunit;
+using static Libplanet.Explorer.UnitTests.GraphQLTestUtils;
+
+namespace Libplanet.Explorer.UnitTests.GraphTypes
+{
+    public class ActionArgumentTypeTest
+    {
+        [Theory]
+        [InlineData("foo", "bar")]
+        [InlineData("integer", 7777)]
+        public async Task Query(object key, object value)
+        {
+            var plainValueKeyValuePair = new PlainValueKeyValuePair
+            {
+                Key = key,
+                Value = value,
+            };
+            var query =
+                @"{
+                    key
+                    value
+                }";
+
+            ExecutionResult result =
+                await ExecuteQueryAsync<ActionArgumentType>(query, source: plainValueKeyValuePair);
+            Dictionary<string, object> resultData = (Dictionary<string, object>)result.Data;
+            Assert.Null(result.Errors);
+            Assert.Equal(key, resultData["key"]);
+            Assert.Equal(value.ToString(), resultData["value"]);
+        }
+    }
+}

--- a/Libplanet.Explorer.UnitTests/GraphTypes/AddressTypeTest.cs
+++ b/Libplanet.Explorer.UnitTests/GraphTypes/AddressTypeTest.cs
@@ -1,0 +1,42 @@
+using System;
+using Libplanet.Explorer.GraphTypes;
+using Xunit;
+
+namespace Libplanet.Explorer.UnitTests.GraphTypes
+{
+    public class AddressTypeTest : ScalarGraphTypeTestBase<AddressType>
+    {
+        [Fact]
+        public void Serialize()
+        {
+            var randomBytes = TestUtils.GetRandomBytes(Address.Size);
+            var randomAddress = new Address(randomBytes);
+            object serialized = _type.Serialize(randomAddress);
+            Assert.Equal(randomAddress.ToString(), serialized);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(0)]
+        [InlineData("")]
+        public void Serialize_ReturnsItselfIfNotAddressType(object value)
+        {
+            Assert.Equal(value, _type.Serialize(value));
+        }
+
+        [Fact]
+        public void ParseValue()
+        {
+            Assert.Null(_type.ParseValue(null));
+            Assert.Equal(new Address(), _type.ParseValue("0x0000000000000000000000000000000000000000"));
+        }
+
+        [Fact]
+        public void ParseValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => _type.ParseValue(0));
+            Assert.Throws<ArgumentException>(() => _type.ParseValue(new Address()));
+            Assert.Throws<ArgumentException>(() => _type.ParseValue(new object()));
+        }
+    }
+}

--- a/Libplanet.Explorer.UnitTests/GraphTypes/BlockTypeTest.cs
+++ b/Libplanet.Explorer.UnitTests/GraphTypes/BlockTypeTest.cs
@@ -35,6 +35,7 @@ namespace Libplanet.Explorer.UnitTests.GraphTypes
                     hash
                     nonce
                     difficulty
+                    totalDifficulty
                     miner
                     timestamp
                     stateRootHash
@@ -52,6 +53,9 @@ namespace Libplanet.Explorer.UnitTests.GraphTypes
             Assert.Equal(
                 block.Difficulty,
                 ((Dictionary<string, object>) result.Data)["difficulty"]);
+            Assert.Equal(
+                block.TotalDifficulty,
+                ((Dictionary<string, object>) result.Data)["totalDifficulty"]);
             Assert.Equal(
                 block.Miner?.ToString(),
                 ((Dictionary<string, object>) result.Data)["miner"]);

--- a/Libplanet.Explorer.UnitTests/GraphTypes/BlockTypeTest.cs
+++ b/Libplanet.Explorer.UnitTests/GraphTypes/BlockTypeTest.cs
@@ -43,31 +43,28 @@ namespace Libplanet.Explorer.UnitTests.GraphTypes
 
             ExecutionResult result =
                 await ExecuteQueryAsync<BlockType<NoOpAction>>(query, source: block);
+            Dictionary<string, object> resultData = (Dictionary<string, object>)result.Data;
             Assert.Null(result.Errors);
-            Assert.Equal(
-                block.Index,
-                ((Dictionary<string, object>) result.Data)["index"]);
+            Assert.Equal(block.Index, resultData["index"]);
             Assert.Equal(
                 ByteUtil.Hex(block.Hash.ToByteArray()),
-                ((Dictionary<string, object>) result.Data)["hash"]);
-            Assert.Equal(
-                block.Difficulty,
-                ((Dictionary<string, object>) result.Data)["difficulty"]);
+                resultData["hash"]);
+            Assert.Equal(block.Difficulty, resultData["difficulty"]);
             Assert.Equal(
                 block.TotalDifficulty,
-                ((Dictionary<string, object>) result.Data)["totalDifficulty"]);
+                resultData["totalDifficulty"]);
             Assert.Equal(
                 block.Miner?.ToString(),
-                ((Dictionary<string, object>) result.Data)["miner"]);
+                resultData["miner"]);
             Assert.Equal(
                 ByteUtil.Hex(block.Nonce.ToByteArray()),
-                ((Dictionary<string, object>) result.Data)["nonce"]);
+                resultData["nonce"]);
             Assert.Equal(
                 new DateTimeOffsetGraphType().Serialize(block.Timestamp),
-                ((Dictionary<string, object>) result.Data)["timestamp"]);
+                resultData["timestamp"]);
             Assert.Equal(
                 ByteUtil.Hex(block.StateRootHash?.ToByteArray()),
-                ((Dictionary<string, object>) result.Data)["stateRootHash"]);
+                resultData["stateRootHash"]);
         }
     }
 }

--- a/Libplanet.Explorer.UnitTests/GraphTypes/BlockTypeTest.cs
+++ b/Libplanet.Explorer.UnitTests/GraphTypes/BlockTypeTest.cs
@@ -45,13 +45,13 @@ namespace Libplanet.Explorer.UnitTests.GraphTypes
             Assert.Null(result.Errors);
             Assert.Equal(
                 block.Index,
-                Convert.ToInt64(((Dictionary<string, object>) result.Data)["index"]));
+                ((Dictionary<string, object>) result.Data)["index"]);
             Assert.Equal(
                 ByteUtil.Hex(block.Hash.ToByteArray()),
                 ((Dictionary<string, object>) result.Data)["hash"]);
             Assert.Equal(
                 block.Difficulty,
-                Convert.ToInt64(((Dictionary<string, object>) result.Data)["difficulty"]));
+                ((Dictionary<string, object>) result.Data)["difficulty"]);
             Assert.Equal(
                 block.Miner?.ToString(),
                 ((Dictionary<string, object>) result.Data)["miner"]);

--- a/Libplanet.Explorer.UnitTests/GraphTypes/ByteStringTypeTest.cs
+++ b/Libplanet.Explorer.UnitTests/GraphTypes/ByteStringTypeTest.cs
@@ -1,0 +1,24 @@
+using Libplanet.Explorer.GraphTypes;
+using Xunit;
+
+namespace Libplanet.Explorer.UnitTests.GraphTypes
+{
+    public class ByteStringTypeTest : ScalarGraphTypeTestBase<ByteStringType>
+    {
+        [Theory]
+        [InlineData(new byte[0], "")]
+        [InlineData(new byte[] { 0xbe, 0xef }, "beef")]
+        public void Serialize(byte[] bytes, string expected)
+        {
+            Assert.Equal(expected, _type.Serialize(bytes));
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData("beef", new byte[] { 0xbe, 0xef })]
+        public void ParseValue(object value, object parsed)
+        {
+            Assert.Equal(parsed, _type.ParseValue(value));
+        }
+    }
+}

--- a/Libplanet.Explorer.UnitTests/GraphTypes/ScalarGraphTypeTestBase.cs
+++ b/Libplanet.Explorer.UnitTests/GraphTypes/ScalarGraphTypeTestBase.cs
@@ -1,0 +1,10 @@
+using GraphQL.Types;
+
+namespace Libplanet.Explorer.UnitTests.GraphTypes
+{
+    public class ScalarGraphTypeTestBase<T>
+        where T : ScalarGraphType, new()
+    {
+        protected readonly T _type = new T();
+    }
+}

--- a/Libplanet.Explorer.UnitTests/GraphTypes/TransactionTypeTest.cs
+++ b/Libplanet.Explorer.UnitTests/GraphTypes/TransactionTypeTest.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using GraphQL;
+using GraphQL.Types;
+using Libplanet.Crypto;
+using Libplanet.Explorer.GraphTypes;
+using Libplanet.Explorer.UnitTests.Common.Action;
+using Libplanet.Tx;
+using Xunit;
+using static Libplanet.Explorer.UnitTests.GraphQLTestUtils;
+
+namespace Libplanet.Explorer.UnitTests.GraphTypes
+{
+    // TODO: test `blockRef`.
+    public class TransactionTypeTest
+    {
+        [Fact]
+        public async Task Query()
+        {
+            var privateKey = new PrivateKey();
+            var transaction = Transaction<NoOpAction>.Create(
+                0,
+                privateKey,
+                new HashDigest<SHA256>(TestUtils.GetRandomBytes(HashDigest<SHA256>.Size)),
+                new[] { new NoOpAction(), });
+            var query =
+                @"{
+                    id
+                    nonce
+                    signer
+                    publicKey
+                    updatedAddresses
+                    signature
+                    timestamp
+                }";
+
+            ExecutionResult result =
+                await ExecuteQueryAsync<TransactionType<NoOpAction>>(query, source: transaction);
+            Dictionary<string, object> resultData = (Dictionary<string, object>)result.Data;
+            Assert.Null(result.Errors);
+            Assert.Equal(transaction.Id.ToHex(), resultData["id"]);
+            Assert.Equal(
+                ByteUtil.Hex(transaction.PublicKey.Format(true)),
+                resultData["publicKey"]);
+            Assert.Equal(transaction.Signer.ToString(), resultData["signer"]);
+            Assert.Equal(ByteUtil.Hex(transaction.Signature), resultData["signature"]);
+            Assert.Equal(transaction.Nonce, resultData["nonce"]);
+            Assert.Equal(
+                new DateTimeOffsetGraphType().Serialize(transaction.Timestamp),
+                resultData["timestamp"]);
+        }
+    }
+}

--- a/Libplanet.Explorer/Controllers/ExplorerController.cs
+++ b/Libplanet.Explorer/Controllers/ExplorerController.cs
@@ -1,4 +1,6 @@
-using GraphQL;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GraphQL.SystemTextJson;
 using GraphQL.Types;
 using Libplanet.Action;
 using Libplanet.Explorer.Interfaces;
@@ -27,13 +29,17 @@ namespace Libplanet.Explorer.Controllers
         }
 
         [HttpPost("/graphql/")]
-        public IActionResult GetGraphQLResult(
+        public async Task<IActionResult> GetGraphQLResult(
             [FromBody] GraphQLBody body
         )
         {
-            var json = _schema.Execute(_ =>
+            var json = await _schema.ExecuteAsync(_ =>
             {
-                _.UserContext = _context;
+                _.UserContext = new Dictionary<string, object>
+                {
+                    [nameof(_context.Store)] = _context.Store,
+                    [nameof(_context.BlockChain)] = _context.BlockChain,
+                };
                 _.Query = body.Query;
                 _.ThrowOnUnhandledException = true;
                 if (body.Variables != null)

--- a/Libplanet.Explorer/GraphTypes/BlockType.cs
+++ b/Libplanet.Explorer/GraphTypes/BlockType.cs
@@ -14,6 +14,7 @@ namespace Libplanet.Explorer.GraphTypes
             Field(x => x.Hash, type: typeof(NonNullGraphType<IdGraphType>));
             Field(x => x.Index);
             Field(x => x.Difficulty);
+            Field(x => x.TotalDifficulty);
             Field<NonNullGraphType<ByteStringType>>(
                 "Nonce",
                 resolve: ctx => ctx.Source.Nonce.ToByteArray()

--- a/Libplanet.Explorer/Libplanet.Explorer.csproj
+++ b/Libplanet.Explorer/Libplanet.Explorer.csproj
@@ -26,7 +26,8 @@
         runtime; build; native; contentfiles; analyzers
       </IncludeAssets>
     </PackageReference>
-    <PackageReference Include="GraphQL" Version="2.4.0" />
+    <PackageReference Include="GraphQL" Version="3.0.0" />
+    <PackageReference Include="GraphQL.SystemTextJson" Version="3.0.0" />
     <PackageReference Include="Libplanet" Version="0.10.0-dev.20200925085741" />
     <PackageReference Include="Libplanet.RocksDBStore" Version="0.10.0-dev.20200925085741" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/Libplanet.Explorer/Queries/BlockQuery.cs
+++ b/Libplanet.Explorer/Queries/BlockQuery.cs
@@ -1,4 +1,5 @@
 using System.Security.Cryptography;
+using GraphQL;
 using GraphQL.Types;
 using Libplanet.Action;
 using Libplanet.Explorer.GraphTypes;

--- a/Libplanet.Explorer/Queries/TransactionQuery.cs
+++ b/Libplanet.Explorer/Queries/TransactionQuery.cs
@@ -1,4 +1,5 @@
 using System;
+using GraphQL;
 using GraphQL.Types;
 using Libplanet.Action;
 using Libplanet.Explorer.GraphTypes;


### PR DESCRIPTION
It will open after #125 merged.

It bumped the version of `GraphQL.NET` to 3, to use `BigIntGraphType` (`BigInteger`). Also it started to support `totalDifficulty` (`Block<T>.TotalDifficulty`) field now.