### PR TITLE
Fix bugs in query

### DIFF
--- a/Libplanet.Explorer/GraphTypes/BlockType.cs
+++ b/Libplanet.Explorer/GraphTypes/BlockType.cs
@@ -23,7 +23,7 @@ namespace Libplanet.Explorer.GraphTypes
             Field<BlockType<T>>(
                 "PreviousBlock",
                 resolve: ctx => ctx.Source.PreviousHash is HashDigest<SHA256> h
-                    ? ((IBlockChainContext<T>)ctx.UserContext).BlockChain[h]
+                    ? ((IBlockChainContext<T>)ctx.UserContext).Store.GetBlock<T>(h)
                     : null
             );
             Field(x => x.Timestamp);

--- a/Libplanet.Explorer/GraphTypes/BlockType.cs
+++ b/Libplanet.Explorer/GraphTypes/BlockType.cs
@@ -1,8 +1,10 @@
 using System.Security.Cryptography;
+using GraphQL;
 using GraphQL.Types;
 using Libplanet.Action;
 using Libplanet.Blocks;
 using Libplanet.Explorer.Interfaces;
+using Libplanet.Store;
 
 namespace Libplanet.Explorer.GraphTypes
 {
@@ -23,7 +25,9 @@ namespace Libplanet.Explorer.GraphTypes
             Field<BlockType<T>>(
                 "PreviousBlock",
                 resolve: ctx => ctx.Source.PreviousHash is HashDigest<SHA256> h
-                    ? ((IBlockChainContext<T>)ctx.UserContext).Store.GetBlock<T>(h)
+                    ? ctx.UserContext[nameof(IBlockChainContext<T>.Store)]
+                        .As<IStore>()
+                        .GetBlock<T>(h)
                     : null
             );
             Field(x => x.Timestamp);

--- a/Libplanet.Explorer/GraphTypes/TransactionType.cs
+++ b/Libplanet.Explorer/GraphTypes/TransactionType.cs
@@ -38,7 +38,7 @@ namespace Libplanet.Explorer.GraphTypes
                     {
                         return richStore
                             .IterateTxReferences(ctx.Source.Id)
-                            .Select(r => blockChainContext.BlockChain[r.Item2]);
+                            .Select(r => blockChainContext.Store.GetBlock<T>(r.Item2));
                     }
                     else
                     {

--- a/Libplanet.Explorer/GraphTypes/TransactionType.cs
+++ b/Libplanet.Explorer/GraphTypes/TransactionType.cs
@@ -33,12 +33,12 @@ namespace Libplanet.Explorer.GraphTypes
                 name: "BlockRef",
                 resolve: ctx =>
                 {
-                    var blockChainContext = (IBlockChainContext<T>)ctx.UserContext;
-                    if (blockChainContext.Store is RichStore richStore)
+                    // FIXME: use store with DI.
+                    if (ctx.UserContext[nameof(IBlockChainContext<T>.Store)] is RichStore richStore)
                     {
                         return richStore
                             .IterateTxReferences(ctx.Source.Id)
-                            .Select(r => blockChainContext.Store.GetBlock<T>(r.Item2));
+                            .Select(r => richStore.GetBlock<T>(r.Item2));
                     }
                     else
                     {

--- a/Libplanet.Explorer/Queries/Query.cs
+++ b/Libplanet.Explorer/Queries/Query.cs
@@ -163,7 +163,7 @@ namespace Libplanet.Explorer.Queries
 
         internal static Block<T> GetBlockByHash(HashDigest<SHA256> hash)
         {
-            return _chain[hash];
+            return _store.GetBlock<T>(hash);
         }
 
         internal static Block<T> GetBlockByIndex(long index)


### PR DESCRIPTION
- Load block from store not chain. It makes users able to query not contained in the canonical chain also.
- Replace `IBlockChainContext<T>` usages in query with `Dictionary<string, object>` because we became to use GraphQL 3.0 since #127 .