### PR TITLE
feat: introduce `workers` option

### DIFF
--- a/Libplanet.Explorer.Executable/Options.cs
+++ b/Libplanet.Explorer.Executable/Options.cs
@@ -43,6 +43,13 @@ namespace Libplanet.Explorer.Executable
         public int DifficultyBoundDivisor { get; set; }
 
         [Option(
+            'W',
+            "workers",
+            Default = 50,
+            HelpText = "The number of swarm workers.")]
+        public int Workers { get; set; }
+
+        [Option(
             'V',
             "app-protocol-version",
             HelpText = "An app protocol version token.")]

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -109,8 +109,8 @@ namespace Libplanet.Explorer.Executable
                         options.AppProtocolVersionToken is string t
                             ? AppProtocolVersion.FromToken(t)
                             : default(AppProtocolVersion),
-                        workers: 50,
                         differentAppProtocolVersionEncountered: (p, pv, lv) => true,
+                        workers: options.Workers,
                         iceServers: new[] { options.IceServer },
                         options: swarmOptions
                     );


### PR DESCRIPTION
When I make explorer connect to Nine Chronicles mainnet, it was too slow and it had too many timeouts. It was because the default value of `Swarm`'s workers was too less (i.e., 5). So I introduced the new option to set the number of swarm workers manually.

PS. I didn't realize it was increased in https://github.com/planetarium/libplanet-explorer/pull/129 🙄. But this pull request has the mean to set workers manually as an option.