### PR TITLE
Install jq inside Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,10 @@ FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
 WORKDIR /app
 COPY --from=build-env /app/out .
 
-# Install native deps
+# Install native deps & utilities for production
 RUN apt-get update \
     && apt-get install -y --allow-unauthenticated \
-        libc6-dev \
+        libc6-dev jq \
      && rm -rf /var/lib/apt/lists/*
 
 # Runtime settings


### PR DESCRIPTION
`jq` is quite useful for writing bash script to check readiness/liveness (k8s' `readinessProbe`/`livenessProbe` in particular).