### PR TITLE
feat(rich-store): support MySQLRichStore

### DIFF
--- a/Libplanet.Explorer.Executable/Options.cs
+++ b/Libplanet.Explorer.Executable/Options.cs
@@ -56,6 +56,36 @@ namespace Libplanet.Explorer.Executable
         public string AppProtocolVersionToken { get; set; }
 
         [Option(
+            "mysql-server",
+            Default = null,
+            HelpText = "A hostname of MySQL server.")]
+        public string MySQLServer { get; set; }
+
+        [Option(
+            "mysql-port",
+            Default = null,
+            HelpText = "A port of MySQL server.")]
+        public uint? MySQLPort { get; set; }
+
+        [Option(
+            "mysql-username",
+            Default = null,
+            HelpText = "The name of MySQL user.")]
+        public string MySQLUsername { get; set; }
+
+        [Option(
+            "mysql-password",
+            Default = null,
+            HelpText = "The password of MySQL user.")]
+        public string MySQLPassword { get; set; }
+
+        [Option(
+            "mysql-database",
+            Default = null,
+            HelpText = "The name of MySQL database to use.")]
+        public string MySQLDatabase { get; set; }
+
+        [Option(
             's',
             "seed",
             HelpText = @"Seed nodes to join to the network as a node. The format of each

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -47,7 +47,7 @@ namespace Libplanet.Explorer.Executable
 
             try
             {
-                RichStore store = LoadStore(options);
+                IRichStore store = LoadStore(options);
 
                 var pendingTxs = store.IterateStagedTransactionIds()
                     .ToImmutableHashSet();
@@ -148,7 +148,7 @@ namespace Libplanet.Explorer.Executable
             }
         }
 
-        private static RichStore LoadStore(Options options)
+        private static IRichStore LoadStore(Options options)
         {
             bool readOnlyMode = options.Seeds is null;
             BaseBlockStatesStore innerStore;
@@ -174,12 +174,33 @@ namespace Libplanet.Explorer.Executable
                         availableStoreTypes);
             }
 
-            return new RichStore(
-                innerStore,
-                path: options.StorePath,
-                flush: false,
-                readOnly: readOnlyMode
-            );
+            bool useMySQL = !string.IsNullOrEmpty(options.MySQLDatabase) &&
+                            !string.IsNullOrEmpty(options.MySQLPassword) &&
+                            !string.IsNullOrEmpty(options.MySQLServer) &&
+                            !string.IsNullOrEmpty(options.MySQLUsername) &&
+                            !(options.MySQLPort is null);
+            if (useMySQL)
+            {
+                var mySqlOptions = new MySQLRichStoreOptions(
+                    options.MySQLDatabase,
+                    options.MySQLServer,
+                    options.MySQLPort.Value,
+                    options.MySQLUsername,
+                    options.MySQLPassword);
+                return new MySQLRichStore(
+                    innerStore,
+                    mySqlOptions
+                );
+            }
+            else
+            {
+                return new RichStore(
+                    innerStore,
+                    path: options.StorePath,
+                    flush: false,
+                    readOnly: readOnlyMode
+                );
+            }
         }
 
         private static async Task StartSwarmAsync(

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -194,7 +194,7 @@ namespace Libplanet.Explorer.Executable
             }
             else
             {
-                return new RichStore(
+                return new LiteDBRichStore(
                     innerStore,
                     path: options.StorePath,
                     flush: false,

--- a/Libplanet.Explorer/GraphTypes/TransactionType.cs
+++ b/Libplanet.Explorer/GraphTypes/TransactionType.cs
@@ -34,7 +34,8 @@ namespace Libplanet.Explorer.GraphTypes
                 resolve: ctx =>
                 {
                     // FIXME: use store with DI.
-                    if (ctx.UserContext[nameof(IBlockChainContext<T>.Store)] is RichStore richStore)
+                    const string storeKey = nameof(IBlockChainContext<T>.Store);
+                    if (ctx.UserContext[storeKey] is IRichStore richStore)
                     {
                         return richStore
                             .IterateTxReferences(ctx.Source.Id)
@@ -42,9 +43,9 @@ namespace Libplanet.Explorer.GraphTypes
                     }
                     else
                     {
-                        ctx.Errors.Add(
-                            new ExecutionError(
-                                $"This feature 'BlockRef' needs{nameof(RichStore)}"));
+                        var exceptionMessage =
+                            $"This feature 'BlockRef' needs{nameof(IRichStore)} implementation";
+                        ctx.Errors.Add(new ExecutionError(exceptionMessage));
                         return null;
                     }
                 });

--- a/Libplanet.Explorer/Libplanet.Explorer.csproj
+++ b/Libplanet.Explorer/Libplanet.Explorer.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <LangVersion>7.2</LangVersion>
+    <LangVersion>8</LangVersion>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Libplanet.Explorer</RootNamespace>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -20,6 +20,9 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.6" />
+    <PackageReference Include="MySqlConnector" Version="1.1.0" />
+    <PackageReference Include="SqlKata" Version="2.2.0" />
+    <PackageReference Include="SqlKata.Execution" Version="2.2.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-beta.61">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>
@@ -39,5 +42,9 @@
 
   <ItemGroup>
     <None Include="wwwroot\*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="Store\RocksDBStoreBitConverter.cs" />
   </ItemGroup>
 </Project>

--- a/Libplanet.Explorer/Queries/Query.cs
+++ b/Libplanet.Explorer/Queries/Query.cs
@@ -93,7 +93,7 @@ namespace Libplanet.Explorer.Queries
                 yield break;
             }
 
-            if (_store is RichStore richStore)
+            if (_store is IRichStore richStore)
             {
                 IEnumerable<TxId> txIds;
                 if (!(signer is null))

--- a/Libplanet.Explorer/Store/LiteDBRichStore.cs
+++ b/Libplanet.Explorer/Store/LiteDBRichStore.cs
@@ -17,7 +17,7 @@ using FileMode = LiteDB.FileMode;
 namespace Libplanet.Explorer.Store
 {
     // It assumes running Explorer as online-mode.
-    public class RichStore : IRichStore
+    public class LiteDBRichStore : IRichStore
     {
         private const string TxRefCollectionName = "block_ref";
         private const string SignerRefCollectionName = "signer_ref";
@@ -30,7 +30,7 @@ namespace Libplanet.Explorer.Store
         // FIXME we should separate it.
         private readonly BaseBlockStatesStore _store;
 
-        public RichStore(
+        public LiteDBRichStore(
             BaseBlockStatesStore store,
             string path,
             bool journal = true,

--- a/Libplanet.Explorer/Store/MySQLRichStore.cs
+++ b/Libplanet.Explorer/Store/MySQLRichStore.cs
@@ -1,0 +1,496 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Security.Cryptography;
+using Bencodex.Types;
+using Libplanet.Action;
+using Libplanet.Blocks;
+using Libplanet.Store;
+using Libplanet.Tx;
+using LruCacheNet;
+using MySqlConnector;
+using Serilog;
+using SqlKata;
+using SqlKata.Compilers;
+using SqlKata.Execution;
+
+namespace Libplanet.Explorer.Store
+{
+    // It assumes running Explorer as online-mode.
+    public class MySQLRichStore : IRichStore
+    {
+        private const string TxRefDbName = "block_ref";
+        private const string SignerRefDbName = "signer_ref";
+        private const string UpdatedAddressRefDbName = "updated_address_ref";
+
+        private readonly LruCache<HashDigest<SHA256>, BlockDigest> _blockCache;
+
+        // FIXME we should separate it.
+        private readonly BaseBlockStatesStore _store;
+
+        private readonly QueryFactory _db;
+
+        public MySQLRichStore(BaseBlockStatesStore store, MySQLRichStoreOptions options)
+        {
+            _store = store;
+
+            var builder = new MySqlConnectionStringBuilder
+            {
+                Database = options.Database,
+                UserID = options.Username,
+                Password = options.Password,
+                Server = options.Server,
+                Port = options.Port,
+            };
+
+            var connection = new MySqlConnection(builder.ConnectionString);
+            var compiler = new MySqlCompiler();
+            _db = new QueryFactory(connection, compiler);
+
+            _blockCache = new LruCache<HashDigest<SHA256>, BlockDigest>(capacity: 512);
+        }
+
+        /// <inheritdoc cref="IStore"/>
+        public long? GetBlockIndex(HashDigest<SHA256> blockHash)
+        {
+            return _store.GetBlockIndex(blockHash);
+        }
+
+        public BlockDigest? GetBlockDigest(HashDigest<SHA256> blockHash)
+        {
+            if (_blockCache.TryGetValue(blockHash, out BlockDigest cachedDigest))
+            {
+                return cachedDigest;
+            }
+
+            var blockDigest = _store.GetBlockDigest(blockHash);
+
+            if (!(blockDigest is null))
+            {
+                _blockCache.AddOrUpdate(blockHash, blockDigest.Value);
+            }
+
+            return blockDigest;
+        }
+
+        /// <inheritdoc cref="IStore"/>
+        public bool DeleteBlock(HashDigest<SHA256> blockHash)
+        {
+            _blockCache.Remove(blockHash);
+
+            return _store.DeleteBlock(blockHash);
+        }
+
+        /// <inheritdoc cref="IStore"/>
+        public bool ContainsBlock(HashDigest<SHA256> blockHash)
+        {
+            if (_blockCache.ContainsKey(blockHash))
+            {
+                return true;
+            }
+
+            return _store.ContainsBlock(blockHash);
+        }
+
+        /// <inheritdoc cref="IStore"/>
+        public IImmutableDictionary<string, IValue> GetBlockStates(HashDigest<SHA256> blockHash)
+        {
+            return _store.GetBlockStates(blockHash);
+        }
+
+        /// <inheritdoc cref="IStore"/>
+        public void SetBlockStates(
+            HashDigest<SHA256> blockHash,
+            IImmutableDictionary<string, IValue> states)
+        {
+            _store.SetBlockStates(blockHash, states);
+        }
+
+        public void PruneBlockStates<T>(Guid chainId, Block<T> until)
+            where T : IAction, new()
+        {
+            _store.PruneBlockStates(chainId, until);
+        }
+
+        /// <inheritdoc cref="IStore"/>
+        public Tuple<HashDigest<SHA256>, long> LookupStateReference<T>(
+            Guid chainId,
+            string key,
+            Block<T> lookupUntil)
+            where T : IAction, new()
+        {
+            return _store.LookupStateReference(chainId, key, lookupUntil.Index);
+        }
+
+        /// <inheritdoc cref="IStore"/>
+        public IEnumerable<Tuple<HashDigest<SHA256>, long>> IterateStateReferences(
+            Guid chainId,
+            string key,
+            long? highestIndex = null,
+            long? lowestIndex = null,
+            int? limit = null)
+        {
+            return _store.IterateStateReferences(
+                chainId,
+                key,
+                highestIndex,
+                lowestIndex,
+                limit);
+        }
+
+        /// <inheritdoc cref="IStore"/>
+        public void StoreStateReference(
+            Guid chainId,
+            IImmutableSet<string> keys,
+            HashDigest<SHA256> blockHash,
+            long blockIndex)
+        {
+            _store.StoreStateReference(chainId, keys, blockHash, blockIndex);
+        }
+
+        /// <inheritdoc cref="IStore"/>
+        public void ForkStateReferences<T>(
+            Guid sourceChainId,
+            Guid destinationChainId,
+            Block<T> branchPoint)
+            where T : IAction, new()
+        {
+            _store.ForkStateReferences(sourceChainId, destinationChainId, branchPoint);
+        }
+
+        /// <inheritdoc cref="IStore"/>
+        public IEnumerable<KeyValuePair<Address, long>> ListTxNonces(Guid chainId)
+        {
+            return _store.ListTxNonces(chainId);
+        }
+
+        /// <inheritdoc cref="IStore"/>
+        public long GetTxNonce(Guid chainId, Address address)
+        {
+            return _store.GetTxNonce(chainId, address);
+        }
+
+        /// <inheritdoc cref="IStore"/>
+        public void IncreaseTxNonce(Guid chainId, Address signer, long delta = 1)
+        {
+            _store.IncreaseTxNonce(chainId, signer, delta);
+        }
+
+        /// <inheritdoc cref="IStore"/>
+        public bool ContainsTransaction(TxId txId)
+        {
+            return _store.ContainsTransaction(txId);
+        }
+
+        /// <inheritdoc cref="IStore"/>
+        public long CountTransactions()
+        {
+            return _store.CountTransactions();
+        }
+
+        /// <inheritdoc cref="IStore"/>
+        public long CountBlocks()
+        {
+            return _store.CountBlocks();
+        }
+
+        /// <inheritdoc cref="IStore"/>
+        public void PutBlock<T>(Block<T> block)
+            where T : IAction, new()
+        {
+            _store.PutBlock(block);
+            foreach (var tx in block.Transactions)
+            {
+                PutTransaction(tx);
+                StoreTxReferences(tx.Id, block.Hash, tx.Nonce);
+            }
+        }
+
+        /// <inheritdoc cref="IStore"/>
+        public IEnumerable<Guid> ListChainIds()
+        {
+            return _store.ListChainIds();
+        }
+
+        /// <inheritdoc cref="IStore"/>
+        public void DeleteChainId(Guid chainId)
+        {
+            _store.DeleteChainId(chainId);
+        }
+
+        /// <inheritdoc cref="IStore"/>
+        public Guid? GetCanonicalChainId()
+        {
+            return _store.GetCanonicalChainId();
+        }
+
+        /// <inheritdoc cref="IStore"/>
+        public void SetCanonicalChainId(Guid chainId)
+        {
+            _store.SetCanonicalChainId(chainId);
+        }
+
+        /// <inheritdoc cref="IStore"/>
+        public long CountIndex(Guid chainId)
+        {
+            return _store.CountIndex(chainId);
+        }
+
+        /// <inheritdoc cref="IStore"/>
+        public IEnumerable<HashDigest<SHA256>> IterateIndexes(
+            Guid chainId,
+            int offset = 0,
+            int? limit = null)
+        {
+            return _store.IterateIndexes(chainId, offset, limit);
+        }
+
+        /// <inheritdoc cref="IStore"/>
+        public HashDigest<SHA256>? IndexBlockHash(Guid chainId, long index)
+        {
+            return _store.IndexBlockHash(chainId, index);
+        }
+
+        /// <inheritdoc cref="IStore"/>
+        public long AppendIndex(Guid chainId, HashDigest<SHA256> hash)
+        {
+            return _store.AppendIndex(chainId, hash);
+        }
+
+        /// <inheritdoc cref="IStore"/>
+        public void ForkBlockIndexes(
+            Guid sourceChainId,
+            Guid destinationChainId,
+            HashDigest<SHA256> branchPoint)
+        {
+            _store.ForkBlockIndexes(sourceChainId, destinationChainId, branchPoint);
+        }
+
+        /// <inheritdoc cref="IStore"/>
+        public IEnumerable<string> ListStateKeys(Guid chainId)
+        {
+            return _store.ListStateKeys(chainId);
+        }
+
+        /// <inheritdoc cref="IStore"/>
+        public IImmutableDictionary<string, IImmutableList<HashDigest<SHA256>>>
+            ListAllStateReferences(
+            Guid chainId,
+            long lowestIndex = 0,
+            long highestIndex = long.MaxValue)
+        {
+            return _store.ListAllStateReferences(chainId, lowestIndex, highestIndex);
+        }
+
+        /// <inheritdoc cref="IStore"/>
+        public void StageTransactionIds(IImmutableSet<TxId> txids)
+        {
+            _store.StageTransactionIds(txids);
+        }
+
+        /// <inheritdoc cref="IStore"/>
+        public void UnstageTransactionIds(ISet<TxId> txids)
+        {
+            _store.UnstageTransactionIds(txids);
+        }
+
+        /// <inheritdoc cref="IStore"/>
+        public IEnumerable<TxId> IterateStagedTransactionIds()
+        {
+            return _store.IterateStagedTransactionIds();
+        }
+
+        /// <inheritdoc cref="IStore"/>
+        public IEnumerable<TxId> IterateTransactionIds()
+        {
+            return _store.IterateTransactionIds();
+        }
+
+        /// <inheritdoc cref="IStore"/>
+        public Transaction<T> GetTransaction<T>(TxId txid)
+            where T : IAction, new()
+        {
+            return _store.GetTransaction<T>(txid);
+        }
+
+        /// <inheritdoc cref="IStore"/>
+        public bool DeleteTransaction(TxId txid)
+        {
+            return _store.DeleteTransaction(txid);
+        }
+
+        /// <inheritdoc cref="IStore"/>
+        public IEnumerable<HashDigest<SHA256>> IterateBlockHashes()
+        {
+            return _store.IterateBlockHashes();
+        }
+
+        /// <inheritdoc cref="IStore"/>
+        public Block<T> GetBlock<T>(HashDigest<SHA256> blockHash)
+            where T : IAction, new()
+        {
+            return _store.GetBlock<T>(blockHash);
+        }
+
+        public void PutTransaction<T>(Transaction<T> tx)
+            where T : IAction, new()
+        {
+            _store.PutTransaction(tx);
+            StoreSignerReferences(tx.Id, tx.Nonce, tx.Signer);
+            InsertMany(
+                "updated_address_references",
+                new[] { "updated_address", "tx_id", "tx_nonce" },
+                tx.UpdatedAddresses.Select(
+                    addr => new object[]
+                    {
+                        addr.ToByteArray(), tx.Id.ToByteArray(), tx.Nonce,
+                    }));
+        }
+
+        public void StoreTxReferences(TxId txId, HashDigest<SHA256> blockHash,  long txNonce)
+        {
+            Insert("tx_references", new Dictionary<string, object>
+            {
+                ["tx_id"] = txId.ToByteArray(),
+                ["tx_nonce"] = txNonce,
+                ["block_hash"] = blockHash.ToByteArray(),
+            });
+        }
+
+        public IEnumerable<ValueTuple<TxId, HashDigest<SHA256>>> IterateTxReferences(
+            TxId? txId = null,
+            bool desc = false,
+            int offset = 0,
+            int limit = int.MaxValue)
+        {
+            Query query = _db.Query("tx_references").Select(new[] { "tx_id", "block_hash" });
+            if (!(txId is null))
+            {
+                query = query.Where("tx_id", txId?.ToByteArray());
+            }
+
+            query = desc ? query.OrderByDesc("tx_nonce") : query.OrderBy("tx_nonce");
+            return query.Offset(offset).Limit(limit).Get<byte[][]>()
+                .Select(row =>
+                    new ValueTuple<TxId, HashDigest<SHA256>>(
+                        new TxId(row[0]),
+                        new HashDigest<SHA256>(row[1])));
+        }
+
+        public void StoreSignerReferences(TxId txId, long txNonce, Address signer)
+        {
+            Insert("signer_references", new Dictionary<string, object>
+            {
+                ["signer"] = signer.ToByteArray(),
+                ["tx_id"] = txId.ToByteArray(),
+                ["tx_nonce"] = txNonce,
+            });
+        }
+
+        public IEnumerable<TxId> IterateSignerReferences(
+            Address signer,
+            bool desc,
+            int offset = 0,
+            int limit = int.MaxValue)
+        {
+            var query = _db.Query("signer_references").Where("signer", signer.ToByteArray())
+                .Offset(offset)
+                .Limit(limit)
+                .Select("tx_id");
+            query = desc ? query.OrderByDesc("tx_nonce") : query.OrderBy("tx_nonce");
+            return query.OrderBy("tx_nonce")
+                .Get<byte[]>()
+                .Select(bytes => new TxId(bytes));
+        }
+
+        public void StoreUpdatedAddressReferences(
+            TxId txId,
+            long txNonce,
+            Address updatedAddress)
+        {
+            Insert("updated_address_references", new Dictionary<string, object>
+            {
+                ["updated_address"] = updatedAddress.ToByteArray(),
+                ["tx_id"] = txId.ToByteArray(),
+                ["tx_nonce"] = txNonce,
+            });
+        }
+
+        public IEnumerable<TxId> IterateUpdatedAddressReferences(
+            Address updatedAddress,
+            bool desc,
+            int offset = 0,
+            int limit = int.MaxValue)
+        {
+            var query = _db.Query("updated_address_references")
+                .Where("updated_address", updatedAddress.ToByteArray())
+                .Offset(offset)
+                .Limit(limit)
+                .Select("tx_id");
+            query = desc ? query.OrderByDesc("tx_nonce") : query.OrderBy("tx_nonce");
+            return query.OrderBy("tx_nonce")
+                .Get<byte[]>()
+                .Select(bytes => new TxId(bytes));
+        }
+
+        public void SetStates<T>(Block<T> block, IImmutableDictionary<string, IValue> states)
+            where T : IAction, new()
+            => _store.SetStates(block, states);
+
+        public IValue GetState(
+            string stateKey,
+            HashDigest<SHA256>? blockHash = null,
+            Guid? chainId = null)
+            => _store.GetState(stateKey);
+
+        public bool ContainsBlockStates(HashDigest<SHA256> blockHash)
+            => _store.ContainsBlockStates(blockHash);
+
+        public void ForkStates<T>(Guid sourceChainId, Guid destinationChainId, Block<T> branchpoint)
+            where T : IAction, new()
+            => _store.ForkStates(sourceChainId, destinationChainId, branchpoint);
+
+        private void Insert(string tableName, IReadOnlyDictionary<string, object> data)
+        {
+            try
+            {
+                _db.Query(tableName).Insert(data);
+            }
+            catch (MySqlException e)
+            {
+                Log.Debug(e.ErrorCode.ToString());
+                if (e.ErrorCode == MySqlErrorCode.DuplicateKeyEntry)
+                {
+                    Log.Debug("Ignore DuplicateKeyEntry");
+                }
+                else
+                {
+                    throw;
+                }
+            }
+        }
+
+        private void InsertMany(
+            string tableName,
+            string[] columns,
+            IEnumerable<object[]> data)
+        {
+            try
+            {
+                _db.Query(tableName).Insert(columns, data);
+            }
+            catch (MySqlException e)
+            {
+                if (e.ErrorCode == MySqlErrorCode.DuplicateKeyEntry)
+                {
+                    Log.Debug("Ignore DuplicateKeyEntry");
+                }
+                else
+                {
+                    throw;
+                }
+            }
+        }
+    }
+}

--- a/Libplanet.Explorer/Store/MySQLRichStoreOptions.cs
+++ b/Libplanet.Explorer/Store/MySQLRichStoreOptions.cs
@@ -1,0 +1,25 @@
+namespace Libplanet.Explorer.Store
+{
+    public readonly struct MySQLRichStoreOptions
+    {
+        public MySQLRichStoreOptions(
+            string database, string server, uint port, string username, string password)
+        {
+            Database = database;
+            Server = server;
+            Port = port;
+            Username = username;
+            Password = password;
+        }
+
+        public string Database { get; }
+
+        public string Server { get; }
+
+        public uint Port { get; }
+
+        public string Username { get; }
+
+        public string Password { get; }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -45,3 +45,17 @@ GraphQL Playground
 This provides a built-in GraphQL Playground.  The web root path serves it:
 
     /
+
+How to use progressive features
+-------------------------------
+
+Now, it uses `IRichStore` to improve transaction query speed
+and provide more usable features (e.g., `blockRef`).
+
+It provides some implementations like below:
+
+ - `LiteDBRichStore`
+ - `MySQLRichStore`
+
+To use `MySQLRichStore`, it needs to fill command line arguments started with `mysql-` prefix fully and correctly.
+Else, it will use `LiteDBRichStore` as default.

--- a/sql/initialize-rich-store.sql
+++ b/sql/initialize-rich-store.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS `tx_references` (
+    CONSTRAINT `uid` UNIQUE (`tx_id`, `block_hash`),
+
+    `tx_id`         BINARY(32),
+    `block_hash`    BINARY(32),
+    `tx_nonce`      BIGINT
+);
+
+CREATE TABLE IF NOT EXISTS `signer_references` (
+    CONSTRAINT `uid` UNIQUE (`signer`, `tx_id`),
+
+    `signer`    BINARY(20),
+    `tx_id`     BINARY(32),
+    `tx_nonce`  BIGINT
+);
+
+CREATE TABLE IF NOT EXISTS `updated_address_references` (
+    CONSTRAINT `uid` UNIQUE (`updated_address`, `tx_id`),
+
+    `updated_address`   BINARY(20),
+    `tx_id`             BINARY(32),
+    `tx_nonce`          BIGINT
+);


### PR DESCRIPTION
In short ways, it provides a new `IRichStore` implementation, `MySQLRichStore`.

Currently, `IRichStore` requires the order function for *desc* option. And I tried to use *ColumnFamily* of *RocksDB* to acheive the requirements but it has an issue to be too slow when the number of column families became bigger than some point. So I thought what database can provide the order feature and can operate stablely. I knew MySQL provides the feature and I had the full trust for that it can operate stablely. I thought also it will provide expandability and opened this pull request.