### PR TITLE
chore: bump libplanet to 0.11.0-dev.20210121021511

### DIFF
--- a/Libplanet.Explorer.Executable/Options.cs
+++ b/Libplanet.Explorer.Executable/Options.cs
@@ -86,6 +86,24 @@ namespace Libplanet.Explorer.Executable
         public string MySQLDatabase { get; set; }
 
         [Option(
+            "max-transactions-per-block",
+            Default = 100,
+            HelpText = "The number of maximum transactions able to be included in a block.")]
+        public int MaxTransactionsPerBlock { get; set; }
+
+        [Option(
+            "max-block-bytes",
+            Default = 100 * 1024,
+            HelpText = "The number of maximum bytes size of blocks except for genesis block.")]
+        public int MaxBlockBytes { get; set; }
+
+        [Option(
+            "max-genesis-bytes",
+            Default = 1024 * 1024,
+            HelpText = "The number of maximum bytes size of the genesis block.")]
+        public int MaxGenesisBytes { get; set; }
+
+        [Option(
             's',
             "seed",
             HelpText = @"Seed nodes to join to the network as a node. The format of each

--- a/Libplanet.Explorer/Libplanet.Explorer.csproj
+++ b/Libplanet.Explorer/Libplanet.Explorer.csproj
@@ -31,8 +31,8 @@
     </PackageReference>
     <PackageReference Include="GraphQL" Version="3.0.0" />
     <PackageReference Include="GraphQL.SystemTextJson" Version="3.0.0" />
-    <PackageReference Include="Libplanet" Version="0.11.0-dev.20201209085742" />
-    <PackageReference Include="Libplanet.RocksDBStore" Version="0.11.0-dev.20201209085742" />
+    <PackageReference Include="Libplanet" Version="0.11.0-dev.20210121021511" />
+    <PackageReference Include="Libplanet.RocksDBStore" Version="0.11.0-dev.20210121021511" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/Libplanet.Explorer/Queries/Query.cs
+++ b/Libplanet.Explorer/Queries/Query.cs
@@ -161,8 +161,7 @@ namespace Libplanet.Explorer.Queries
                     $"{nameof(ListStagedTransactions)} doesn't support negative offset.");
             }
 
-            var stagedTxs = _store.IterateStagedTransactionIds()
-                .Select(txId => _chain.GetTransaction(txId))
+            var stagedTxs = _chain.StagePolicy.Iterate(_chain)
                 .Where(tx => IsValidTransacion(tx, signer, involved))
                 .Skip(offset);
 

--- a/Libplanet.Explorer/Store/IRichStore.cs
+++ b/Libplanet.Explorer/Store/IRichStore.cs
@@ -6,7 +6,7 @@ using Libplanet.Tx;
 
 namespace Libplanet.Explorer.Store
 {
-    public interface IRichStore : IStore, IStateStore
+    public interface IRichStore : IStore
     {
         void StoreTxReferences(TxId txId, HashDigest<SHA256> blockHash, long blockIndex);
 

--- a/Libplanet.Explorer/Store/LiteDBRichStore.cs
+++ b/Libplanet.Explorer/Store/LiteDBRichStore.cs
@@ -28,10 +28,10 @@ namespace Libplanet.Explorer.Store
         private readonly LruCache<HashDigest<SHA256>, BlockDigest> _blockCache;
 
         // FIXME we should separate it.
-        private readonly BaseBlockStatesStore _store;
+        private readonly IStore _store;
 
         public LiteDBRichStore(
-            BaseBlockStatesStore store,
+            IStore store,
             string path,
             bool journal = true,
             int indexCacheSize = 50000,
@@ -125,72 +125,6 @@ namespace Libplanet.Explorer.Store
             }
 
             return _store.ContainsBlock(blockHash);
-        }
-
-        /// <inheritdoc cref="IStore"/>
-        public IImmutableDictionary<string, IValue> GetBlockStates(HashDigest<SHA256> blockHash)
-        {
-            return _store.GetBlockStates(blockHash);
-        }
-
-        /// <inheritdoc cref="IStore"/>
-        public void SetBlockStates(
-            HashDigest<SHA256> blockHash,
-            IImmutableDictionary<string, IValue> states)
-        {
-            _store.SetBlockStates(blockHash, states);
-        }
-
-        public void PruneBlockStates<T>(Guid chainId, Block<T> until)
-            where T : IAction, new()
-        {
-            _store.PruneBlockStates(chainId, until);
-        }
-
-        /// <inheritdoc cref="IStore"/>
-        public Tuple<HashDigest<SHA256>, long> LookupStateReference<T>(
-            Guid chainId,
-            string key,
-            Block<T> lookupUntil)
-            where T : IAction, new()
-        {
-            return _store.LookupStateReference(chainId, key, lookupUntil.Index);
-        }
-
-        /// <inheritdoc cref="IStore"/>
-        public IEnumerable<Tuple<HashDigest<SHA256>, long>> IterateStateReferences(
-            Guid chainId,
-            string key,
-            long? highestIndex = null,
-            long? lowestIndex = null,
-            int? limit = null)
-        {
-            return _store.IterateStateReferences(
-                chainId,
-                key,
-                highestIndex,
-                lowestIndex,
-                limit);
-        }
-
-        /// <inheritdoc cref="IStore"/>
-        public void StoreStateReference(
-            Guid chainId,
-            IImmutableSet<string> keys,
-            HashDigest<SHA256> blockHash,
-            long blockIndex)
-        {
-            _store.StoreStateReference(chainId, keys, blockHash, blockIndex);
-        }
-
-        /// <inheritdoc cref="IStore"/>
-        public void ForkStateReferences<T>(
-            Guid sourceChainId,
-            Guid destinationChainId,
-            Block<T> branchPoint)
-            where T : IAction, new()
-        {
-            _store.ForkStateReferences(sourceChainId, destinationChainId, branchPoint);
         }
 
         /// <inheritdoc cref="IStore"/>
@@ -306,22 +240,6 @@ namespace Libplanet.Explorer.Store
             HashDigest<SHA256> branchPoint)
         {
             _store.ForkBlockIndexes(sourceChainId, destinationChainId, branchPoint);
-        }
-
-        /// <inheritdoc cref="IStore"/>
-        public IEnumerable<string> ListStateKeys(Guid chainId)
-        {
-            return _store.ListStateKeys(chainId);
-        }
-
-        /// <inheritdoc cref="IStore"/>
-        public IImmutableDictionary<string, IImmutableList<HashDigest<SHA256>>>
-            ListAllStateReferences(
-            Guid chainId,
-            long lowestIndex = 0,
-            long highestIndex = long.MaxValue)
-        {
-            return _store.ListAllStateReferences(chainId, lowestIndex, highestIndex);
         }
 
         /// <inheritdoc cref="IStore"/>
@@ -474,23 +392,6 @@ namespace Libplanet.Explorer.Store
             );
             return collection.Find(query, offset, limit).Select(doc => doc.TxId);
         }
-
-        public void SetStates<T>(Block<T> block, IImmutableDictionary<string, IValue> states)
-            where T : IAction, new()
-            => _store.SetStates(block, states);
-
-        public IValue GetState(
-            string stateKey,
-            HashDigest<SHA256>? blockHash = null,
-            Guid? chainId = null)
-            => _store.GetState(stateKey);
-
-        public bool ContainsBlockStates(HashDigest<SHA256> blockHash)
-            => _store.ContainsBlockStates(blockHash);
-
-        public void ForkStates<T>(Guid sourceChainId, Guid destinationChainId, Block<T> branchpoint)
-            where T : IAction, new()
-            => _store.ForkStates(sourceChainId, destinationChainId, branchpoint);
 
         private LiteCollection<TxRefDoc> TxRefCollection() =>
             _db.GetCollection<TxRefDoc>(TxRefCollectionName);

--- a/Libplanet.Explorer/Store/MySQLRichStore.cs
+++ b/Libplanet.Explorer/Store/MySQLRichStore.cs
@@ -27,12 +27,12 @@ namespace Libplanet.Explorer.Store
         private readonly LruCache<HashDigest<SHA256>, BlockDigest> _blockCache;
 
         // FIXME we should separate it.
-        private readonly BaseBlockStatesStore _store;
+        private readonly IStore _store;
 
         private readonly MySqlCompiler _compiler;
         private readonly string _connectionString;
 
-        public MySQLRichStore(BaseBlockStatesStore store, MySQLRichStoreOptions options)
+        public MySQLRichStore(IStore store, MySQLRichStoreOptions options)
         {
             _store = store;
 
@@ -91,72 +91,6 @@ namespace Libplanet.Explorer.Store
             }
 
             return _store.ContainsBlock(blockHash);
-        }
-
-        /// <inheritdoc cref="IStore"/>
-        public IImmutableDictionary<string, IValue> GetBlockStates(HashDigest<SHA256> blockHash)
-        {
-            return _store.GetBlockStates(blockHash);
-        }
-
-        /// <inheritdoc cref="IStore"/>
-        public void SetBlockStates(
-            HashDigest<SHA256> blockHash,
-            IImmutableDictionary<string, IValue> states)
-        {
-            _store.SetBlockStates(blockHash, states);
-        }
-
-        public void PruneBlockStates<T>(Guid chainId, Block<T> until)
-            where T : IAction, new()
-        {
-            _store.PruneBlockStates(chainId, until);
-        }
-
-        /// <inheritdoc cref="IStore"/>
-        public Tuple<HashDigest<SHA256>, long> LookupStateReference<T>(
-            Guid chainId,
-            string key,
-            Block<T> lookupUntil)
-            where T : IAction, new()
-        {
-            return _store.LookupStateReference(chainId, key, lookupUntil.Index);
-        }
-
-        /// <inheritdoc cref="IStore"/>
-        public IEnumerable<Tuple<HashDigest<SHA256>, long>> IterateStateReferences(
-            Guid chainId,
-            string key,
-            long? highestIndex = null,
-            long? lowestIndex = null,
-            int? limit = null)
-        {
-            return _store.IterateStateReferences(
-                chainId,
-                key,
-                highestIndex,
-                lowestIndex,
-                limit);
-        }
-
-        /// <inheritdoc cref="IStore"/>
-        public void StoreStateReference(
-            Guid chainId,
-            IImmutableSet<string> keys,
-            HashDigest<SHA256> blockHash,
-            long blockIndex)
-        {
-            _store.StoreStateReference(chainId, keys, blockHash, blockIndex);
-        }
-
-        /// <inheritdoc cref="IStore"/>
-        public void ForkStateReferences<T>(
-            Guid sourceChainId,
-            Guid destinationChainId,
-            Block<T> branchPoint)
-            where T : IAction, new()
-        {
-            _store.ForkStateReferences(sourceChainId, destinationChainId, branchPoint);
         }
 
         /// <inheritdoc cref="IStore"/>
@@ -265,22 +199,6 @@ namespace Libplanet.Explorer.Store
             HashDigest<SHA256> branchPoint)
         {
             _store.ForkBlockIndexes(sourceChainId, destinationChainId, branchPoint);
-        }
-
-        /// <inheritdoc cref="IStore"/>
-        public IEnumerable<string> ListStateKeys(Guid chainId)
-        {
-            return _store.ListStateKeys(chainId);
-        }
-
-        /// <inheritdoc cref="IStore"/>
-        public IImmutableDictionary<string, IImmutableList<HashDigest<SHA256>>>
-            ListAllStateReferences(
-            Guid chainId,
-            long lowestIndex = 0,
-            long highestIndex = long.MaxValue)
-        {
-            return _store.ListAllStateReferences(chainId, lowestIndex, highestIndex);
         }
 
         /// <inheritdoc cref="IStore"/>
@@ -435,23 +353,6 @@ namespace Libplanet.Explorer.Store
                 .Get<byte[]>()
                 .Select(bytes => new TxId(bytes));
         }
-
-        public void SetStates<T>(Block<T> block, IImmutableDictionary<string, IValue> states)
-            where T : IAction, new()
-            => _store.SetStates(block, states);
-
-        public IValue GetState(
-            string stateKey,
-            HashDigest<SHA256>? blockHash = null,
-            Guid? chainId = null)
-            => _store.GetState(stateKey);
-
-        public bool ContainsBlockStates(HashDigest<SHA256> blockHash)
-            => _store.ContainsBlockStates(blockHash);
-
-        public void ForkStates<T>(Guid sourceChainId, Guid destinationChainId, Block<T> branchpoint)
-            where T : IAction, new()
-            => _store.ForkStates(sourceChainId, destinationChainId, branchpoint);
 
         private QueryFactory OpenDB() =>
             new QueryFactory(new MySqlConnection(_connectionString), _compiler);


### PR DESCRIPTION
## Changes

### Added command line options

- `--max-block-bytes` for `BlockPolicy<T>.ctor`'s `maxBlockBytes`
- `--max-genesis-bytes` for `BlockPolicy<T>.ctor`'s `maxGenesisBytes`
- `--max-transactions-per-block` for `BlockPolicy<T>.ctor`'s `maxTransactionsPerBlock`

### Bump dependencies

It bumps `Libplanet` and `Libplanet.RocksDBStore` to `0.11.0-dev.20210121021511` from `0.11.0-dev.20201209085742`.