### PR TITLE
ci(gh-actions): bump checkout version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2.3.4
     - uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '3.1.302'

--- a/.github/workflows/push_docker_image.yml
+++ b/.github/workflows/push_docker_image.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-16.04
     steps:
       - name: checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2.3.4
       - name: login
         run: docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       - name: build


### PR DESCRIPTION
Since [GitHub started to use main](https://github.com/github/renaming), the actions/checkout@master was staled. So we should be away from it and follow the main branch. And tag is not affected such it so I believe it is the best way to use tag.