### PR TITLE
ci(gh-actions): publish 'Libplanet.Explorer' to NuGet 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,3 +10,23 @@ jobs:
         dotnet-version: '3.1.302'
     - run: dotnet build
     - run: dotnet test
+    - name: NuGet publish
+      run: |
+        dotnet_args="-c Release -p:NoPackageAnalysis=true"
+        if [[ ! "$GITHUB_REF" =~ ^refs/tags/* ]]; then
+          git_sha=`echo "${{ github.sha }}" | cut -c1-11`
+          publish_datetime=`TZ=UTC date +%Y%m%d%H%M%S`
+          version_suffix=dev."$publish_datetime"+git.sha."$git_sha"
+          dotnet_args="$dotnet_args --version-suffix $version_suffix"
+        fi
+
+        dotnet pack Libplanet.Explorer $dotnet_args
+
+        if [[ "$NUGET_API_KEY" != "" ]]; then
+          dotnet nuget push ./Libplanet.Explorer/bin/Release/Libplanet.Explorer.*.nupkg \
+            --api-key "$NUGET_API_KEY" \
+            --source https://api.nuget.org/v3/index.json
+        fi
+      if: github.event_name != 'pull_request' && success()
+      env:
+        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/Libplanet.Explorer/Libplanet.Explorer.csproj
+++ b/Libplanet.Explorer/Libplanet.Explorer.csproj
@@ -1,9 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <PackageId>Libplanet.Explorer</PackageId>
     <LangVersion>8</LangVersion>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Libplanet.Explorer</RootNamespace>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <PackageProjectUrl>https://github.com/planetarium/libplanet-explorer</PackageProjectUrl>
+    <RepositoryUrl>git://github.com/planetarium/libplanet-explorer.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <Company>Planetarium</Company>
+    <Authors>Planetarium</Authors>
+    <VersionPrefix>0.1.0</VersionPrefix>
     <NoWarn>NU1701</NoWarn>
     <CodeAnalysisRuleSet>..\Libplanet.Explorer.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>


### PR DESCRIPTION
Since this pull request, GitHub Actions `build` workflow will become to publish `Libplanet.Explorer` project to NuGet for each `push` event if the build successes. You can see the published package [here](https://www.nuget.org/packages/Libplanet.Explorer/0.1.0-dev.20210223053002).

It uses version suffix including with build metadata `dev.<TIMESTAMP>+git.sha.<CUT-11-LENGTH-SHA1>` format (e.g. ` 0.1.0-dev.20210223044246+git.sha.0bb87f56b82`). It uses cut 11-length Git SHA1 hash because NuGet limits version length to 64. According to https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection, the commits of Linux kernel project can be presented in secure with 11-length hash.