### PR TITLE
Feature/multiple options

### DIFF
--- a/Libplanet.Explorer.Executable/Libplanet.Explorer.Executable.csproj
+++ b/Libplanet.Explorer.Executable/Libplanet.Explorer.Executable.csproj
@@ -27,7 +27,6 @@
         runtime; build; native; contentfiles; analyzers
       </IncludeAssets>
     </PackageReference>
-    <PackageReference Include="CommandLineParser" Version="2.6.0" />
     <PackageReference Include="Cocona.Lite" Version="1.5.0" />
   </ItemGroup>
 

--- a/Libplanet.Explorer.Executable/Libplanet.Explorer.Executable.csproj
+++ b/Libplanet.Explorer.Executable/Libplanet.Explorer.Executable.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>NU1701,SA1118,SA1201,MEN003</NoWarn>
+    <NoWarn>NU1701,SA1118,MEN003</NoWarn>
     <CodeAnalysisRuleSet>..\Libplanet.Explorer.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/Libplanet.Explorer.Executable/Libplanet.Explorer.Executable.csproj
+++ b/Libplanet.Explorer.Executable/Libplanet.Explorer.Executable.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>NU1701,SA1118</NoWarn>
+    <NoWarn>NU1701,SA1118,SA1201,MEN003</NoWarn>
     <CodeAnalysisRuleSet>..\Libplanet.Explorer.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
@@ -28,6 +28,7 @@
       </IncludeAssets>
     </PackageReference>
     <PackageReference Include="CommandLineParser" Version="2.6.0" />
+    <PackageReference Include="Cocona.Lite" Version="1.5.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -38,5 +39,5 @@
     <Content Include="wwwroot\**\*">
       <CopyToPublishDirectory>Always</CopyToPublishDirectory>
     </Content>
-</ItemGroup>
+  </ItemGroup>
 </Project>

--- a/Libplanet.Explorer.Executable/Libplanet.Explorer.Executable.csproj
+++ b/Libplanet.Explorer.Executable/Libplanet.Explorer.Executable.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>NU1701,SA1118,MEN003</NoWarn>
+    <NoWarn>NU1701,SA1118</NoWarn>
     <CodeAnalysisRuleSet>..\Libplanet.Explorer.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/Libplanet.Explorer.Executable/Options.cs
+++ b/Libplanet.Explorer.Executable/Options.cs
@@ -99,7 +99,7 @@ namespace Libplanet.Explorer.Executable
 
             set
             {
-                Seeds = value.Select(str =>
+                Seeds = value?.Select(str =>
                 {
                     string[] parts = str.Split(',');
                     if (parts.Length != 3)

--- a/Libplanet.Explorer.Executable/Options.cs
+++ b/Libplanet.Explorer.Executable/Options.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Net;
-using CommandLine;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
 using Libplanet.Net;
@@ -12,104 +10,38 @@ namespace Libplanet.Explorer.Executable
 {
     public class Options
     {
-        [Option('d', "debug", HelpText = "Print logs for debugging as well.")]
         public bool Debug { get; set; }
 
-        [Option('H', "host", Default = "0.0.0.0", HelpText = "The host address to listen.")]
         public string Host { get; set; }
 
-        [Option('p', "port", Default = 5000, HelpText = "The port number to listen.")]
         public int Port { get; set; }
 
-        [Option(
-            'i',
-            "block-interval",
-            Default = 5000,
-            HelpText = "An appropriate interval in milliseconds between consecutive blocks.")]
         public int BlockIntervalMilliseconds { get; set; }
 
-        [Option(
-            'm',
-            "minimum-difficulty",
-            Default = 1024L,
-            HelpText = "Allowed minimum difficulty for mining blocks.")]
         public long MinimumDifficulty { get; set; }
 
-        [Option(
-            'D',
-            "difficulty-bound-divisor",
-            Default = 128,
-            HelpText = "A bound divisor to determine precision of block difficulties.")]
         public int DifficultyBoundDivisor { get; set; }
 
-        [Option(
-            'W',
-            "workers",
-            Default = 50,
-            HelpText = "The number of swarm workers.")]
         public int Workers { get; set; }
 
-        [Option(
-            'V',
-            "app-protocol-version",
-            HelpText = "An app protocol version token.")]
         public string AppProtocolVersionToken { get; set; }
 
-        [Option(
-            "mysql-server",
-            Default = null,
-            HelpText = "A hostname of MySQL server.")]
         public string MySQLServer { get; set; }
 
-        [Option(
-            "mysql-port",
-            Default = null,
-            HelpText = "A port of MySQL server.")]
         public uint? MySQLPort { get; set; }
 
-        [Option(
-            "mysql-username",
-            Default = null,
-            HelpText = "The name of MySQL user.")]
         public string MySQLUsername { get; set; }
 
-        [Option(
-            "mysql-password",
-            Default = null,
-            HelpText = "The password of MySQL user.")]
         public string MySQLPassword { get; set; }
 
-        [Option(
-            "mysql-database",
-            Default = null,
-            HelpText = "The name of MySQL database to use.")]
         public string MySQLDatabase { get; set; }
 
-        [Option(
-            "max-transactions-per-block",
-            Default = 100,
-            HelpText = "The number of maximum transactions able to be included in a block.")]
         public int MaxTransactionsPerBlock { get; set; }
 
-        [Option(
-            "max-block-bytes",
-            Default = 100 * 1024,
-            HelpText = "The number of maximum bytes size of blocks except for genesis block.")]
         public int MaxBlockBytes { get; set; }
 
-        [Option(
-            "max-genesis-bytes",
-            Default = 1024 * 1024,
-            HelpText = "The number of maximum bytes size of the genesis block.")]
         public int MaxGenesisBytes { get; set; }
 
-        [Option(
-            's',
-            "seed",
-            HelpText = @"Seed nodes to join to the network as a node. The format of each
-seed is a comma-separated triple of a peer's hexadecimal public key, host, and port number.
-E.g., `02ed49dbe0f2c34d9dff8335d6dd9097f7a3ef17dfb5f048382eebc7f451a50aa1,example.com,31234'.
-If omitted (default) explorer only the local blockchain store.")]
         public IEnumerable<string> SeedStrings
         {
             get
@@ -139,10 +71,6 @@ If omitted (default) explorer only the local blockchain store.")]
 
         public IEnumerable<BoundPeer> Seeds { get; set; }
 
-        [Option(
-            'I',
-            "ice-server",
-            HelpText = "URL to ICE server (TURN/STUN) to work around NAT.")]
         public string IceServerUrl
         {
             get
@@ -177,27 +105,10 @@ If omitted (default) explorer only the local blockchain store.")]
 
         public IceServer IceServer { get; set; }
 
-        [Option(
-            'P',
-            "store-path",
-            Default = null,
-            HelpText = @"The path of the blockchain store. If omitted (default)
-in memory version is used.")]
         public string StorePath { get; set; }
 
-        [Option(
-            'T',
-            "store-type",
-            Default = null,
-            HelpText = @"The type of the blockchain store. If omitted (default)
-in DefaultStore is used.")]
         public string StoreType { get; set; }
 
-        [Option(
-            'G',
-            "genesis-block",
-            HelpText = "The path of the genesis block. It should be absolute or http url.",
-            Required = true)]
         public string GenesisBlockPath { get; set; }
 
         internal Block<Program.AppAgnosticAction> GenesisBlock
@@ -213,29 +124,51 @@ in DefaultStore is used.")]
             }
         }
 
-        public static Options Parse(string[] args, TextWriter errorWriter)
+        public Options(
+            bool debug,
+            string host,
+            int port,
+            int blockIntervalMilliseconds,
+            long minimumDifficulty,
+            int difficultyBoundDivisor,
+            int workers,
+            string appProtocolVersionToken,
+            string mysqlServer,
+            uint? mysqlPort,
+            string mysqlUsername,
+            string mysqlPassword,
+            string mysqlDatabase,
+            int maxTransactionsPerBlock,
+            int maxBlockBytes,
+            int maxGenesisBytes,
+            IEnumerable<string> seedStrings,
+            string iceServerUrl,
+            string storePath,
+            string storeType,
+            string genesisBlockPath
+        )
         {
-            var parser = new Parser(with =>
-            {
-                with.AutoHelp = true;
-                with.EnableDashDash = true;
-                with.HelpWriter = errorWriter;
-            });
-            ParserResult<Options> result = parser.ParseArguments<Options>(args);
-
-            if (result is Parsed<Options> parsed)
-            {
-                Options options = parsed.Value;
-                return options;
-            }
-            else if (result is NotParsed<Options> notParsed)
-            {
-                System.Environment.Exit(
-                    notParsed.Errors.All(e => e.Tag is ErrorType.HelpRequestedError) ? 0 : 1
-                );
-            }
-
-            return null;
+            Debug = debug;
+            Host = host;
+            Port = port;
+            BlockIntervalMilliseconds = blockIntervalMilliseconds;
+            MinimumDifficulty = minimumDifficulty;
+            DifficultyBoundDivisor = difficultyBoundDivisor;
+            Workers = workers;
+            AppProtocolVersionToken = appProtocolVersionToken;
+            MySQLServer = mysqlServer;
+            MySQLPort = mysqlPort;
+            MySQLUsername = mysqlUsername;
+            MySQLPassword = mysqlPassword;
+            MySQLDatabase = mysqlDatabase;
+            MaxTransactionsPerBlock = maxTransactionsPerBlock;
+            MaxBlockBytes = maxBlockBytes;
+            MaxGenesisBytes = maxGenesisBytes;
+            SeedStrings = seedStrings;
+            IceServerUrl = iceServerUrl;
+            StorePath = storePath;
+            StoreType = storeType;
+            GenesisBlockPath = genesisBlockPath;
         }
     }
 }

--- a/Libplanet.Explorer.Executable/Options.cs
+++ b/Libplanet.Explorer.Executable/Options.cs
@@ -10,6 +10,53 @@ namespace Libplanet.Explorer.Executable
 {
     public class Options
     {
+        public Options(
+            bool debug,
+            string host,
+            int port,
+            int blockIntervalMilliseconds,
+            long minimumDifficulty,
+            int difficultyBoundDivisor,
+            int workers,
+            string appProtocolVersionToken,
+            string mysqlServer,
+            uint? mysqlPort,
+            string mysqlUsername,
+            string mysqlPassword,
+            string mysqlDatabase,
+            int maxTransactionsPerBlock,
+            int maxBlockBytes,
+            int maxGenesisBytes,
+            IEnumerable<string> seedStrings,
+            string iceServerUrl,
+            string storePath,
+            string storeType,
+            string genesisBlockPath
+        )
+        {
+            Debug = debug;
+            Host = host;
+            Port = port;
+            BlockIntervalMilliseconds = blockIntervalMilliseconds;
+            MinimumDifficulty = minimumDifficulty;
+            DifficultyBoundDivisor = difficultyBoundDivisor;
+            Workers = workers;
+            AppProtocolVersionToken = appProtocolVersionToken;
+            MySQLServer = mysqlServer;
+            MySQLPort = mysqlPort;
+            MySQLUsername = mysqlUsername;
+            MySQLPassword = mysqlPassword;
+            MySQLDatabase = mysqlDatabase;
+            MaxTransactionsPerBlock = maxTransactionsPerBlock;
+            MaxBlockBytes = maxBlockBytes;
+            MaxGenesisBytes = maxGenesisBytes;
+            SeedStrings = seedStrings;
+            IceServerUrl = iceServerUrl;
+            StorePath = storePath;
+            StoreType = storeType;
+            GenesisBlockPath = genesisBlockPath;
+        }
+
         public bool Debug { get; set; }
 
         public string Host { get; set; }
@@ -122,53 +169,6 @@ namespace Libplanet.Explorer.Executable
                     return Block<Program.AppAgnosticAction>.Deserialize(serialized);
                 }
             }
-        }
-
-        public Options(
-            bool debug,
-            string host,
-            int port,
-            int blockIntervalMilliseconds,
-            long minimumDifficulty,
-            int difficultyBoundDivisor,
-            int workers,
-            string appProtocolVersionToken,
-            string mysqlServer,
-            uint? mysqlPort,
-            string mysqlUsername,
-            string mysqlPassword,
-            string mysqlDatabase,
-            int maxTransactionsPerBlock,
-            int maxBlockBytes,
-            int maxGenesisBytes,
-            IEnumerable<string> seedStrings,
-            string iceServerUrl,
-            string storePath,
-            string storeType,
-            string genesisBlockPath
-        )
-        {
-            Debug = debug;
-            Host = host;
-            Port = port;
-            BlockIntervalMilliseconds = blockIntervalMilliseconds;
-            MinimumDifficulty = minimumDifficulty;
-            DifficultyBoundDivisor = difficultyBoundDivisor;
-            Workers = workers;
-            AppProtocolVersionToken = appProtocolVersionToken;
-            MySQLServer = mysqlServer;
-            MySQLPort = mysqlPort;
-            MySQLUsername = mysqlUsername;
-            MySQLPassword = mysqlPassword;
-            MySQLDatabase = mysqlDatabase;
-            MaxTransactionsPerBlock = maxTransactionsPerBlock;
-            MaxBlockBytes = maxBlockBytes;
-            MaxGenesisBytes = maxGenesisBytes;
-            SeedStrings = seedStrings;
-            IceServerUrl = iceServerUrl;
-            StorePath = storePath;
-            StoreType = storeType;
-            GenesisBlockPath = genesisBlockPath;
         }
     }
 }

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -38,6 +38,14 @@ namespace Libplanet.Explorer.Executable
 
         [Command(Description = "Run libplanet-explorer with options.")]
         public async Task Run(
+            [Option(
+                "seed",
+                new[] { 's' },
+                Description = @"Seed nodes to join to the network as a node. The format of each
+seed is a comma-separated triple of a peer's hexadecimal public key, host, and port number.
+E.g., `02ed49dbe0f2c34d9dff8335d6dd9097f7a3ef17dfb5f048382eebc7f451a50aa1,example.com,31234'.
+If omitted (default) explorer only the local blockchain store.")]
+            string[] seedStrings,
             [Option("debug", new[] { 'd' }, Description = "Print logs for debugging as well.")]
             bool debug = false,
             [Option("host", new[] { 'H' }, Description = "The host address to listen.")]
@@ -105,14 +113,6 @@ for genesis block.")]
                 Description = "The number of maximum bytes size of the genesis block.")]
             int maxGenesisBytes = 1024 * 1024,
             [Option(
-                "seed",
-                new[] { 's' },
-                Description = @"Seed nodes to join to the network as a node. The format of each
-seed is a comma-separated triple of a peer's hexadecimal public key, host, and port number.
-E.g., `02ed49dbe0f2c34d9dff8335d6dd9097f7a3ef17dfb5f048382eebc7f451a50aa1,example.com,31234'.
-If omitted (default) explorer only the local blockchain store.")]
-            string[] seedStrings = null,
-            [Option(
                 "ice-server",
                 new[] { 'I' },
                 Description = "URL to ICE server (TURN/STUN) to work around NAT.")]
@@ -137,27 +137,27 @@ in DefaultStore is used.")]
         )
         {
             Options options = new Options(
-            debug,
-            host,
-            port,
-            blockIntervalMilliseconds,
-            minimumDifficulty,
-            difficultyBoundDivisor,
-            workers,
-            appProtocolVersionToken,
-            mysqlServer,
-            mysqlPort,
-            mysqlUsername,
-            mysqlPassword,
-            mysqlDatabase,
-            maxTransactionsPerBlock,
-            maxBlockBytes,
-            maxGenesisBytes,
-            seedStrings,
-            iceServerUrl,
-            storePath,
-            storeType,
-            genesisBlockPath);
+                debug,
+                host,
+                port,
+                blockIntervalMilliseconds,
+                minimumDifficulty,
+                difficultyBoundDivisor,
+                workers,
+                appProtocolVersionToken,
+                mysqlServer,
+                mysqlPort,
+                mysqlUsername,
+                mysqlPassword,
+                mysqlDatabase,
+                maxTransactionsPerBlock,
+                maxBlockBytes,
+                maxGenesisBytes,
+                seedStrings,
+                iceServerUrl,
+                storePath,
+                storeType,
+                genesisBlockPath);
 
             var loggerConfig = new LoggerConfiguration();
             loggerConfig = options.Debug
@@ -297,7 +297,7 @@ in DefaultStore is used.")]
                 default:
                     // FIXME: give available store type as argument hint without code duplication.
                     var availableStoreTypes = new[] { "rocksdb", "default" };
-                    string longOptionName = "store-type";
+                    const string longOptionName = "store-type";
                     throw new InvalidOptionValueException(
                         "--" + longOptionName,
                         options.StoreType,

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -39,13 +39,22 @@ namespace Libplanet.Explorer.Executable
         [Command(Description = "Run libplanet-explorer with options.")]
         public async Task Run(
             [Option(
-                "seed",
-                new[] { 's' },
-                Description = @"Seed nodes to join to the network as a node. The format of each
-seed is a comma-separated triple of a peer's hexadecimal public key, host, and port number.
-E.g., `02ed49dbe0f2c34d9dff8335d6dd9097f7a3ef17dfb5f048382eebc7f451a50aa1,example.com,31234'.
-If omitted (default) explorer only the local blockchain store.")]
-            string[] seedStrings,
+                "store-path",
+                new[] { 'P' },
+                Description = @"The path of the blockchain store. If omitted (default)
+in memory version is used.")]
+            string storePath,
+            [Option(
+                "store-type",
+                new[] { 'T' },
+                Description = @"The type of the blockchain store. If omitted (default)
+in DefaultStore is used.")]
+            string storeType,
+            [Option(
+                "genesis-block",
+                new[] { 'G' },
+                Description = "The path of the genesis block. It should be absolute or http url.")]
+            string genesisBlockPath,
             [Option("debug", new[] { 'd' }, Description = "Print logs for debugging as well.")]
             bool debug = false,
             [Option("host", new[] { 'H' }, Description = "The host address to listen.")]
@@ -113,27 +122,18 @@ for genesis block.")]
                 Description = "The number of maximum bytes size of the genesis block.")]
             int maxGenesisBytes = 1024 * 1024,
             [Option(
+                "seed",
+                new[] { 's' },
+                Description = @"Seed nodes to join to the network as a node. The format of each
+seed is a comma-separated triple of a peer's hexadecimal public key, host, and port number.
+E.g., `02ed49dbe0f2c34d9dff8335d6dd9097f7a3ef17dfb5f048382eebc7f451a50aa1,example.com,31234'.
+If omitted (default) explorer only the local blockchain store.")]
+            string[] seedStrings = null,
+            [Option(
                 "ice-server",
                 new[] { 'I' },
                 Description = "URL to ICE server (TURN/STUN) to work around NAT.")]
-            string iceServerUrl = null,
-            [Option(
-                "store-path",
-                new[] { 'P' },
-                Description = @"The path of the blockchain store. If omitted (default)
-in memory version is used.")]
-            string storePath = null,
-            [Option(
-                "store-type",
-                new[] { 'T' },
-                Description = @"The type of the blockchain store. If omitted (default)
-in DefaultStore is used.")]
-            string storeType = null,
-            [Option(
-                "genesis-block",
-                new[] { 'G' },
-                Description = "The path of the genesis block. It should be absolute or http url.")]
-            string genesisBlockPath = null
+            string iceServerUrl = null
         )
         {
             Options options = new Options(
@@ -201,7 +201,7 @@ in DefaultStore is used.")]
                     .Build();
 
                 Swarm<AppAgnosticAction> swarm = null;
-                if (options.Seeds.Any())
+                if (!(options.Seeds is null))
                 {
                     string aggregatedSeedStrings =
                         options.SeedStrings.Aggregate(string.Empty, (s, s1) => s + s1);

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Threading;
@@ -37,6 +38,10 @@ namespace Libplanet.Explorer.Executable
         }
 
         [Command(Description = "Run libplanet-explorer with options.")]
+        [SuppressMessage(
+            "Microsoft.StyleCop.CSharp.ReadabilityRules",
+            "MEN003",
+            Justification = "Many lines are required for running the method.")]
         public async Task Run(
             [Option(
                 "store-path",


### PR DESCRIPTION
This PR migrates from `CommandLineParser` to `Cocona.Lite` to take multiple `seed` and `ice-server` arguments.

Example args:
![Screen Shot 2021-02-23 at 11 36 23 PM](https://user-images.githubusercontent.com/42176649/108858822-f328a600-762f-11eb-93e1-a6335167ce6d.png)
