### PR TITLE
fix(graphql): override ParseLiteral correctly

### DIFF
--- a/Libplanet.Explorer.UnitTests/GraphTypes/ByteStringTypeTest.cs
+++ b/Libplanet.Explorer.UnitTests/GraphTypes/ByteStringTypeTest.cs
@@ -1,3 +1,4 @@
+using GraphQL.Language.AST;
 using Libplanet.Explorer.GraphTypes;
 using Xunit;
 
@@ -19,6 +20,22 @@ namespace Libplanet.Explorer.UnitTests.GraphTypes
         public void ParseValue(object value, object parsed)
         {
             Assert.Equal(parsed, _type.ParseValue(value));
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData("beef", new byte[] { 0xbe, 0xef })]
+        public void ParseLiteral(string stringValue, object parsed)
+        {
+            Assert.Equal(parsed, _type.ParseLiteral(new StringValue(stringValue)));
+        }
+
+        [Fact]
+        public void ParseLiteral_NotStringValue_ReturnNull()
+        {
+            Assert.Null(_type.ParseLiteral(new IntValue(0)));
+            Assert.Null(_type.ParseLiteral(new BigIntValue(0)));
+            Assert.Null(_type.ParseLiteral(new EnumValue("NAME")));
         }
     }
 }

--- a/Libplanet.Explorer/GraphTypes/ByteStringType.cs
+++ b/Libplanet.Explorer/GraphTypes/ByteStringType.cs
@@ -1,4 +1,5 @@
 using System;
+using GraphQL.Language.AST;
 using GraphQL.Types;
 
 namespace Libplanet.Explorer.GraphTypes
@@ -26,6 +27,15 @@ namespace Libplanet.Explorer.GraphTypes
                 default:
                     throw new ArgumentException("Expected a hexadecimal string.", nameof(value));
             }
+        }
+
+        public override object ParseLiteral(IValue value)
+        {
+            return value switch
+            {
+                StringValue stringValue => ParseValue(stringValue.Value),
+                _ => null,
+            };
         }
     }
 }


### PR DESCRIPTION
Before this pull request, `ByteStringType` didn't override its `ParseLiteral` method so it didn't work well when used as input.