### PR TITLE
enrich mysqlrichstore

### DIFF
--- a/Models/BlockModel.cs
+++ b/Models/BlockModel.cs
@@ -1,0 +1,33 @@
+namespace MySqlStore.Models
+{
+    public class BlockModel
+    {
+        public int Index { get; set; }
+
+        public string Hash { get; set; }
+
+        public string PreEvaluationHash { get; set; }
+
+        public string StateRootHash { get; set; }
+
+        public long Difficulty { get; set; }
+
+        public long TotalDifficulty { get; set; }
+
+        public string Nonce { get; set; }
+
+        public string Miner { get; set; }
+
+        public string PreviousHash { get; set; }
+
+        public string Timestamp { get; set; }
+
+        public string TxHash { get; set; }
+
+        public string ByteLength { get; set; }
+
+        public byte[] Key { get; set; }
+
+        public byte[] Value { get; set; }
+    }
+}

--- a/Models/BlockPerceptionModel.cs
+++ b/Models/BlockPerceptionModel.cs
@@ -1,0 +1,9 @@
+namespace MySqlStore.Models
+{
+    public class BlockPerceptionModel
+    {
+        public byte[] Key { get; set; }
+
+        public byte[] Perceived_Time { get; set; }
+    }
+}

--- a/Models/ChainModel.cs
+++ b/Models/ChainModel.cs
@@ -1,0 +1,13 @@
+namespace MySqlStore.Models
+{
+    public class ChainModel
+    {
+        public byte[] Key { get; set; }
+
+        public byte[] Value { get; set; }
+
+        public string Cf { get; set; }
+
+        public byte[] Prefix { get; set; }
+    }
+}

--- a/Models/KeyValueModel.cs
+++ b/Models/KeyValueModel.cs
@@ -1,0 +1,9 @@
+namespace MySqlStore.Models
+{
+    public class KeyValueModel
+    {
+        public byte[] Key { get; set; }
+
+        public byte[] Value { get; set; }
+    }
+}

--- a/Models/TransactionModel.cs
+++ b/Models/TransactionModel.cs
@@ -1,0 +1,25 @@
+namespace MySqlStore.Models
+{
+    public class TransactionModel
+    {
+        public string TxId { get; set; }
+
+        public string Nonce { get; set; }
+
+        public string Signer { get; set; }
+
+        public string Signature { get; set; }
+
+        public string Timestamp { get; set; }
+
+        public string PublicKey { get; set; }
+
+        public string GenesisHash { get; set; }
+
+        public string BytesLength { get; set; }
+
+        public byte[] Key { get; set; }
+
+        public byte[] Value { get; set; }
+    }
+}

--- a/sql/initialize-rich-store.sql
+++ b/sql/initialize-rich-store.sql
@@ -21,3 +21,33 @@ CREATE TABLE IF NOT EXISTS `updated_address_references` (
     `tx_id`             BINARY(32),
     `tx_nonce`          BIGINT
 );
+
+CREATE TABLE IF NOT EXISTS `block` (
+  `index`                 BIGINT,
+  `hash`                  BINARY(32),
+  `pre_evaluation_hash`   BINARY(32),
+  `state_root_hash`       BINARY(32),
+  `difficulty`            BIGINT,
+  `total_difficulty`      BIGINT,
+  `nonce`                 BINARY(32),
+  `miner`                 BINARY(32),
+  `previous_hash`         BINARY(32),
+  `timestamp`             VARCHAR,
+  `tx_hash`               BINARY(32),
+  `bytes_length`          INT,
+    PRIMARY KEY (`hash`),
+    UNIQUE INDEX `hash_UNIQUE` (`hash` ASC)
+);
+
+CREATE TABLE IF NOT EXISTS `transaction` (
+  `tx_id`               BINARY(32),
+  `nonce`               BIGINT,
+  `signer`              BINARY(20),
+  `signature`           BINARY(71),
+  `timestamp`           VARCHAR,
+  `public_key`          VARCHAR,
+  `genesis_hash`        BINARY(32),
+  `bytes_length`        INT,
+  PRIMARY KEY (`tx_id`),
+  UNIQUE INDEX `tx_id_UNIQUE` (`tx_id` ASC)
+);


### PR DESCRIPTION
This PR enriches `MySqlRichStore` to store `block` and `transaction` data.

In [this section](https://github.com/planetarium/libplanet-explorer/compare/main...area363:feature/enrich-mysqlrichstore?expand=1#diff-3e6c1427b9b3c3d3db323726233a0ce84120721145b6572b94f15769855989e9R306-R334), I'm using MySqlBulkLoader to store `updated_address` data in the tx. 

`Genesis block` has around 50,000 records of `updated_addresses`. And so, storing these entries during preloading took around 5 minutes with the original implementation. With bulk loading, the time has decreased to about 5 seconds.

However, I've been running into some issues bulk loading byte arrays into the table. When I just use `addr.ToByteArray()` [here](https://github.com/planetarium/libplanet-explorer/compare/main...area363:feature/enrich-mysqlrichstore?expand=1#diff-3e6c1427b9b3c3d3db323726233a0ce84120721145b6572b94f15769855989e9R314-R317), the data is converted to a string. I'm wondering if there are other ways to bulk load byte array data. 🤔 