### PR TITLE
Fix ByteStringType.Serialize

### DIFF
--- a/Libplanet.Explorer.UnitTests/GraphTypes/ByteStringTypeTest.cs
+++ b/Libplanet.Explorer.UnitTests/GraphTypes/ByteStringTypeTest.cs
@@ -9,9 +9,12 @@ namespace Libplanet.Explorer.UnitTests.GraphTypes
         [Theory]
         [InlineData(new byte[0], "")]
         [InlineData(new byte[] { 0xbe, 0xef }, "beef")]
-        public void Serialize(byte[] bytes, string expected)
+        [InlineData("foo", "foo")]
+        [InlineData(1, null)]
+        [InlineData(null, null)]
+        public void Serialize(object value, string expected)
         {
-            Assert.Equal(expected, _type.Serialize(bytes));
+            Assert.Equal(expected, _type.Serialize(value));
         }
 
         [Theory]

--- a/Libplanet.Explorer/GraphTypes/ByteStringType.cs
+++ b/Libplanet.Explorer/GraphTypes/ByteStringType.cs
@@ -13,7 +13,12 @@ namespace Libplanet.Explorer.GraphTypes
 
         public override object Serialize(object value)
         {
-            return value is byte[] b ? ByteUtil.Hex(b) : null;
+            return value switch
+            {
+                byte[] b => ByteUtil.Hex(b),
+                string s => s,
+                _ => null
+            };
         }
 
         public override object ParseValue(object value)


### PR DESCRIPTION
- Fix `ByteStringType.Serailize()` in [GraphQLExtensions.AstFromValue](https://github.com/graphql-dotnet/graphql-dotnet/blob/master/src/GraphQL/GraphQLExtensions.cs#L456)